### PR TITLE
Allow specifying device type when initializing LRCer object

### DIFF
--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -51,7 +51,7 @@ class LRCer:
         retry_model: The model to use when retrying the translation. Default: None
     """
 
-    def __init__(self, whisper_model='large-v3', compute_type='float16', chatbot_model: str = 'gpt-3.5-turbo',
+    def __init__(self, whisper_model='large-v3', compute_type='float16', device='cuda', chatbot_model: str = 'gpt-3.5-turbo',
                  fee_limit=0.25, consumer_thread=4, asr_options=None, vad_options=None, preprocess_options=None,
                  proxy=None, base_url_config=None, glossary: Union[dict, str, Path] = None, retry_model=None):
         self.chatbot_model = chatbot_model
@@ -84,7 +84,7 @@ class LRCer:
         if preprocess_options:
             self.preprocess_options.update(preprocess_options)
 
-        self.transcriber = Transcriber(model_name=whisper_model, compute_type=compute_type,
+        self.transcriber = Transcriber(model_name=whisper_model, compute_type=compute_type, device=device,
                                        asr_options=self.asr_options, vad_options=self.vad_options)
         self.transcribed_paths = []
 


### PR DESCRIPTION
Thank you for creating this package. This helped me to a great extent.

Since I can't afford nvida gpu price. I had to test my code on a cpu-only machine and then rent a pay-per-hour gpu server for video transcription.

I want to be able to specify the device type when creating the LCRer object.
I successfully transcribed a short mp4 file using the following code and poetry dependencies

``` python
    lrcer = LRCer(whisper_model="tiny", compute_type='int16', device="cpu")
    lrcer.run(audios, target_lang='en', skip_trans=True)
```

``` toml
# file: pyproject.toml
[tool.poetry.dependencies]
...
openlrc = "^1.4.0"
faster-whisper = "^1.0.2"

torch = { version = "~2.2", source = "pytorch-cpu", markers = "extra=='cpu' and extra!='cuda'" }
torchvision = { version = "~0.17", source = "pytorch-cpu", markers = "extra=='cpu' and extra!='cuda'" }
torchaudio = { version = "~2.2", source = "pytorch-cpu", markers = "extra=='cpu' and extra!='cuda'" }

[tool.poetry.extras]
cpu = ["torch", "torchvision", "torchaudio"]
cuda = ["torch", "torchvision", "torchaudio"]

[[tool.poetry.source]]
name = "pytorch-cpu"
url = "https://download.pytorch.org/whl/cpu"
priority = "explicit"
```