### PR TITLE
allow to translate existed subtitles

### DIFF
--- a/openlrc/subtitle.py
+++ b/openlrc/subtitle.py
@@ -51,6 +51,10 @@ class Subtitle:
         return Subtitle(filename=filename, **content)
 
     @staticmethod
+    def to_json(filename):
+        raise NotImplementedError
+
+    @staticmethod
     def from_file(filename):
         filename = Path(filename)
         suffix = filename.suffix


### PR DESCRIPTION
- make `transcription_queue ` as class member
- add `add_existed_subtitles` as a new producer function
- need to realize **`Subtitle.to_json()`** method

I want to use lrc to translate existing subtitle files. A simpler solution is to add a new producer function, which can add existing subtitle files to the queue.
This is roughly what it looks like, but I don't known how to implement the **`Subtitle.to_json()`** method, so this code is actually unfinished. Any suggestions or help will be appreciated.