### PR TITLE
Decouple transcription and translation in LRCer

### DIFF
--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -175,7 +175,8 @@ class LRCer:
         if isinstance(paths, (str, Path)):
             paths = [paths]
 
-        paths = list(map(Path, paths))
+        # Keep behavior aligned with pre_process(): de-duplicate repeated inputs.
+        paths = [Path(p) for p in set(paths)]
 
         if skip_preprocess:
             audio_paths = [get_preprocessed_path(p) for p in paths]
@@ -196,6 +197,21 @@ class LRCer:
     def _get_base_name(transcribed_path: Path) -> str:
         """Extract the original audio base name from a transcribed JSON path."""
         return transcribed_path.stem.replace('_preprocessed_transcribed', '')
+
+    def _is_video_transcription(self, transcribed_path: Path, base_name: str) -> bool:
+        """
+        Determine whether a transcribed file originated from a video source.
+
+        In normal run() flows, self.from_video is populated during preprocessing.
+        For standalone translate() usage, infer from an existing source file next to
+        the output directory when possible.
+        """
+        source_stem = transcribed_path.parent.parent / base_name
+        if source_stem in self.from_video:
+            return True
+
+        video_suffixes = ('.mp4', '.mkv', '.mov', '.avi', '.webm', '.ts', '.m4v', '.flv', '.wmv')
+        return any(source_stem.with_suffix(suffix).exists() for suffix in video_suffixes)
 
     def _build_final_subtitle(self, base_name, target_lang, transcribed_opt_sub, skip_trans):
         """
@@ -287,7 +303,7 @@ class LRCer:
             bilingual_sub (bool): Whether to generate bilingual subtitles.
         """
         base_name = self._get_base_name(transcribed_path)
-        subtitle_format = 'srt' if transcribed_path.parent.parent / base_name in self.from_video else 'lrc'
+        subtitle_format = 'srt' if self._is_video_transcription(transcribed_path, base_name) else 'lrc'
 
         transcribed_sub = Subtitle.from_json(transcribed_path)
         transcribed_opt_sub = self.post_process(transcribed_sub, update_name=True)

--- a/tests/test_openlrc.py
+++ b/tests/test_openlrc.py
@@ -175,6 +175,28 @@ class TestLRCer(unittest.TestCase):
 
     @patch('openlrc.translate.LLMTranslator.translate',
            MagicMock(return_value=['test translation1', 'test translation2']))
+    def test_translate_independent_video_transcription_outputs_srt(self):
+        """translate() should keep video-origin output as .srt even on a fresh LRCer."""
+        lrcer_transcribe = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        transcribed = lrcer_transcribe.transcribe(self.video_path)
+        self.assertEqual(len(transcribed), 1)
+
+        lrcer_translate = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        result = lrcer_translate.translate(transcribed, target_lang='zh-cn')
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].suffix, '.srt')
+
+    @patch('openlrc.translate.LLMTranslator.translate')
+    def test_run_skip_trans_deduplicates_duplicate_inputs(self, mock_translate):
+        """run(skip_trans=True) should transcribe duplicate input paths only once."""
+        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        result = lrcer.run([self.audio_path, self.audio_path], skip_trans=True)
+        self.assertTrue(result)
+        self.assertEqual(len(result), 1)
+        mock_translate.assert_not_called()
+
+    @patch('openlrc.translate.LLMTranslator.translate',
+           MagicMock(return_value=['test translation1', 'test translation2']))
     def test_run_full_pipeline(self):
         """run() with default args should produce subtitle output (full pipeline)."""
         lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')


### PR DESCRIPTION

## Summary

Add independent `transcribe()` and `translate()` public methods to `LRCer`, allowing users to run transcription and translation as separate stages instead of only through the monolithic `run()` method.

## Motivation

Currently `LRCer.run()` is the only entry point, tightly coupling transcription and translation in a producer-consumer thread model. This makes it impossible to:

- Transcribe once and translate later (or multiple times to different languages)
- Use only transcription without initializing translation infrastructure
- Integrate transcription results into external workflows before translating

## Changes

### New public API

- **`transcribe(paths, src_lang, noise_suppress, skip_preprocess)`** — Runs preprocessing and transcription only, returns paths to transcribed JSON files.
- **`translate(transcribed_paths, target_lang, bilingual_sub)`** — Translates previously transcribed JSON files and generates subtitle output.

### Internal refactoring

Extracted shared logic from `produce_transcriptions()`, `translation_worker()`, and `run()`'s `skip_trans` branch into reusable private methods:

| Method | Responsibility |
|---|---|
| `_transcribe_single()` | Transcribe a single audio file |
| `_get_base_name()` | Extract original audio name from transcribed JSON path |
| `_build_final_subtitle()` | Build final subtitle object (via translation or copy) |
| `_generate_subtitle_files()` | Export and move subtitle file to output directory |
| `_handle_bilingual_subtitles()` | Generate bilingual subtitle output |
| `_process_transcribed_file()` | Orchestrate the above for a single file |

`translation_worker()`, `translate()`, and `run()`'s `skip_trans` branch all delegate to `_process_transcribed_file()`, eliminating the previously triplicated logic.

### Behavioral change in `run(skip_trans=True)`

Previously, `skip_trans=True` still launched the full producer-consumer thread pool, passing `skip_trans` through to `translation_worker`. Now it short-circuits: transcribes sequentially and generates subtitles directly, without spawning translation threads.

### Tests

- `test_transcribe_returns_json_paths` — `transcribe()` returns JSON paths without triggering translation.
- `test_translate_processes_transcribed_json` — `translate()` processes transcribed JSON and invokes `LLMTranslator`.
- `test_run_full_pipeline` — `run()` full pipeline remains functional.

## Usage example

```python
lrcer = LRCer(...)

# Stage 1: transcribe
json_paths = lrcer.transcribe('audio.wav')

# Stage 2: translate (can be done later, or skipped entirely)
subtitle_paths = lrcer.translate(json_paths, target_lang='zh-cn')
