### PR TITLE
Introduce TranscriptionConfig/TranslationConfig dataclasses

### DIFF
--- a/openlrc/__init__.py
+++ b/openlrc/__init__.py
@@ -2,8 +2,9 @@
 #  All rights reserved.
 
 from openlrc.models import list_chatbot_models, ModelConfig, ModelProvider
-from openlrc.openlrc import LRCer
+from openlrc.openlrc import LRCer, TranscriptionConfig, TranslationConfig
 
-__all__ = ('LRCer', 'ModelConfig', 'list_chatbot_models', 'ModelProvider')
+__all__ = ('LRCer', 'TranscriptionConfig', 'TranslationConfig',
+           'ModelConfig', 'list_chatbot_models', 'ModelProvider')
 __version__ = '1.5.2'
 __author__ = 'zh-plus'

--- a/openlrc/gui_streamlit/home.py
+++ b/openlrc/gui_streamlit/home.py
@@ -10,7 +10,7 @@ from st_pages import Page, show_pages
 from streamlit_extras.bottom_container import bottom
 from streamlit_extras.mention import mention
 
-from openlrc import LRCer
+from openlrc import LRCer, TranscriptionConfig, TranslationConfig
 from openlrc.gui_streamlit.utils import get_asr_options, get_vad_options, get_preprocess_options, zip_files
 
 show_pages([
@@ -173,19 +173,25 @@ if submitted:
     src_lang = None if src_lang == 'Auto Detect' else src_lang
 
     with st.spinner('Running...'):
-        lrcer = LRCer(whisper_model=whisper_model, compute_type=compute_type, chatbot_model=chatbot_model,
-                      fee_limit=fee_limit, consumer_thread=consumer_thread,
-                      asr_options=get_asr_options(
-                          beam_size, best_of, patience, length_penalty, repetition_penalty, no_repeat_ngram_size,
-                          temperature, compression_ratio_threshold, log_prob_threshold, no_speech_threshold,
-                          condition_on_previous_text, initial_prompt, prefix, suppress_blank, suppress_tokens,
-                          without_timestamps, max_initial_timestamp, word_timestamps, prepend_punctuations,
-                          append_punctuations, hallucination_silence_threshold),
-                      vad_options=get_vad_options(
-                          threshold, min_speech_duration_ms, max_speech_duration_s, min_silence_duration_ms,
-                          window_size_samples, speech_pad_ms),
-                      preprocess_options=get_preprocess_options(atten_lim_db),
-                      proxy=proxy, )
+        lrcer = LRCer(
+            transcription=TranscriptionConfig(
+                whisper_model=whisper_model, compute_type=compute_type,
+                asr_options=get_asr_options(
+                    beam_size, best_of, patience, length_penalty, repetition_penalty, no_repeat_ngram_size,
+                    temperature, compression_ratio_threshold, log_prob_threshold, no_speech_threshold,
+                    condition_on_previous_text, initial_prompt, prefix, suppress_blank, suppress_tokens,
+                    without_timestamps, max_initial_timestamp, word_timestamps, prepend_punctuations,
+                    append_punctuations, hallucination_silence_threshold),
+                vad_options=get_vad_options(
+                    threshold, min_speech_duration_ms, max_speech_duration_s, min_silence_duration_ms,
+                    window_size_samples, speech_pad_ms),
+                preprocess_options=get_preprocess_options(atten_lim_db),
+            ),
+            translation=TranslationConfig(
+                chatbot_model=chatbot_model, fee_limit=fee_limit,
+                consumer_thread=consumer_thread, proxy=proxy,
+            ),
+        )
         results = lrcer.run(paths, src_lang=src_lang, target_lang=target_lang,
                             skip_trans=skip_trans, noise_suppress=noise_suppress, bilingual_sub=bilingual_sub)
     print(paths)

--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -5,12 +5,14 @@ import concurrent.futures
 import json
 import shutil
 import traceback
+import warnings
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 from queue import Queue
 from threading import Lock
-from typing import List, Union, Optional
+from typing import Any, List, Union, Optional
 
 from faster_whisper.transcribe import Segment
 
@@ -26,66 +28,164 @@ from openlrc.translate import LLMTranslator
 from openlrc.utils import Timer, extend_filename, get_audio_duration, format_timestamp, extract_audio, \
     get_file_type, get_preprocessed_path
 
+_SENTINEL = object()
+
+
+@dataclass
+class TranscriptionConfig:
+    """
+    Configuration for the transcription stage.
+
+    Args:
+        whisper_model: Name of whisper model. Default: ``large-v3``
+        compute_type: Computation type (``default``, ``int8``, ``int8_float16``,
+            ``int16``, ``float16``, ``float32``). Default: ``float16``
+        device: Device for computation. Default: ``cuda``
+        asr_options: Parameters for whisper model.
+        vad_options: Parameters for VAD model.
+        preprocess_options: Options for audio preprocessing.
+    """
+    whisper_model: str = 'large-v3'
+    compute_type: str = 'float16'
+    device: str = 'cuda'
+    asr_options: Optional[dict] = None
+    vad_options: Optional[dict] = None
+    preprocess_options: Optional[dict] = None
+
+
+@dataclass
+class TranslationConfig:
+    """
+    Configuration for the translation stage.
+
+    Args:
+        chatbot_model: The chatbot model to use. Can be a string like
+            ``'gpt-4.1-nano'`` or ``'provider:model-name'``, or a ``ModelConfig``
+            instance. Default: ``gpt-4.1-nano``
+        fee_limit: Maximum fee per translation call in USD. Default: ``0.8``
+        consumer_thread: Number of parallel translation threads. Default: ``4``
+        proxy: Proxy for API requests. e.g. ``'http://127.0.0.1:7890'``
+        base_url_config: Base URL dict for OpenAI & Anthropic.
+        glossary: Dictionary or path mapping source words to translations.
+        retry_model: Fallback model for translation retries.
+        is_force_glossary_used: Force glossary usage in context. Default: ``False``
+    """
+    chatbot_model: Union[str, ModelConfig] = 'gpt-4.1-nano'
+    fee_limit: float = 0.8
+    consumer_thread: int = 4
+    proxy: Optional[str] = None
+    base_url_config: Optional[dict] = None
+    glossary: Optional[Union[dict, str, Path]] = None
+    retry_model: Optional[Union[str, ModelConfig]] = None
+    is_force_glossary_used: bool = False
+
 
 class LRCer:
     """
-    Args:
-        whisper_model (str): Name of whisper model (tiny, tiny.en, base, base.en, small, small.en, medium,
-            medium.en, large-v1, large-v2, large-v3, distill-large-v3) When a size is configured,
-            the converted model is downloaded from the Hugging Face Hub. Default: ``large-v3``
-        compute_type (str): The type of computation to use. Can be ``default``, ``int8``, ``int8_float16``, ``int16``,
-            ``float16`` or ``float32``. Default: ``float16``
-            Note: ``default`` will keep the same quantization that was used during model conversion.
-        device (str): The device to use for computation. Default: ``cuda``
-        chatbot_model (Union[str, ModelConfig]): The chatbot model to use, check the available models using list_chatbot_models().
-            The string can be '<model-name>' or '<provider>:<model-name>'. e.g. 'gpt-4.1-nano' or 'openai:gpt-4.1-nano'.
-            The ModelConfig can be ModelConfig(model_name='<model-name>', provider='<provider>', base_url='<url>', proxy='<proxy>').
-            Default: ``gpt-4.1-nano``
-        fee_limit (float): The maximum fee you are willing to pay for one translation call. Default: ``0.8``
-        consumer_thread (int): To prevent exceeding the RPM and TPM limits set by OpenAI, the default is TPM/MAX_TOKEN.
-        asr_options (Optional[dict]): Parameters for whisper model.
-        vad_options (Optional[dict]): Parameters for VAD model.
-        preprocess_options (Optional[dict]): Options for audio preprocessing.
-        proxy (Optional[str]): Proxy for openai requests. e.g. 'http://127.0.0.1:7890'
-        base_url_config (Optional[dict]): Base URL dict for OpenAI & Anthropic.
-            e.g. {'openai': 'https://openai.justsong.cn/', 'anthropic': 'https://api.g4f.icu'}
-            Default: ``None``
-        glossary (Optional[Union[dict, str, Path]]): A dictionary mapping specific source words to their desired translations. 
-            This is used to enforce custom translations that override the default behavior of the translation model. 
-            Each key-value pair in the dictionary specifies a source word and its corresponding translation. Default: None.
-        retry_model (Optional[Union[str, ModelConfig]]): The model to use when retrying the translation. Default: None.
-        is_force_glossary_used (bool): Whether to force the given glossary to be used in context. Default: False
+    Orchestrator for audio/video transcription and translation.
+
+    Preferred usage (config objects)::
+
+        lrcer = LRCer(
+            transcription=TranscriptionConfig(whisper_model='large-v3', device='cuda'),
+            translation=TranslationConfig(chatbot_model='gpt-4.1-nano', fee_limit=1.0),
+        )
+
+    Legacy keyword arguments are still accepted but deprecated and will be
+    removed in a future release::
+
+        # Deprecated — emits DeprecationWarning
+        lrcer = LRCer(whisper_model='large-v3', chatbot_model='gpt-4.1-nano')
     """
 
-    def __init__(self, whisper_model: str = 'large-v3', compute_type: str = 'float16', device: str = 'cuda',
-                 chatbot_model: Union[str, ModelConfig] = 'gpt-4.1-nano', fee_limit: float = 0.8,
-                 consumer_thread: int = 4,
-                 asr_options: Optional[dict] = None, vad_options: Optional[dict] = None,
-                 preprocess_options: Optional[dict] = None, proxy: Optional[str] = None,
-                 base_url_config: Optional[dict] = None, glossary: Optional[Union[dict, str, Path]] = None,
-                 retry_model: Optional[Union[str, ModelConfig]] = None, is_force_glossary_used: bool = False):
-        self.chatbot_model = chatbot_model
-        self.fee_limit = fee_limit
+    def __init__(self, *,
+                 transcription: Optional[TranscriptionConfig] = None,
+                 translation: Optional[TranslationConfig] = None,
+                 # Legacy keyword arguments — deprecated
+                 whisper_model: Any = _SENTINEL, compute_type: Any = _SENTINEL,
+                 device: Any = _SENTINEL, chatbot_model: Any = _SENTINEL,
+                 fee_limit: Any = _SENTINEL, consumer_thread: Any = _SENTINEL,
+                 asr_options: Any = _SENTINEL, vad_options: Any = _SENTINEL,
+                 preprocess_options: Any = _SENTINEL, proxy: Any = _SENTINEL,
+                 base_url_config: Any = _SENTINEL, glossary: Any = _SENTINEL,
+                 retry_model: Any = _SENTINEL, is_force_glossary_used: Any = _SENTINEL):
+
+        # Detect whether any legacy keyword was explicitly passed.
+        legacy_kwargs = {
+            'whisper_model': whisper_model, 'compute_type': compute_type, 'device': device,
+            'chatbot_model': chatbot_model, 'fee_limit': fee_limit, 'consumer_thread': consumer_thread,
+            'asr_options': asr_options, 'vad_options': vad_options, 'preprocess_options': preprocess_options,
+            'proxy': proxy, 'base_url_config': base_url_config, 'glossary': glossary,
+            'retry_model': retry_model, 'is_force_glossary_used': is_force_glossary_used,
+        }
+        legacy_used = {k: v for k, v in legacy_kwargs.items() if v is not _SENTINEL}
+
+        if legacy_used:
+            warnings.warn(
+                "Passing keyword arguments directly to LRCer() is deprecated and will be removed in a future "
+                "release. Use TranscriptionConfig / TranslationConfig instead. "
+                "See https://github.com/zh-plus/openlrc/issues/81 for migration details.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if legacy_used and (transcription is not None or translation is not None):
+            raise ValueError(
+                "Cannot mix legacy keyword arguments with TranscriptionConfig/TranslationConfig. "
+                "Use one style or the other."
+            )
+
+        if legacy_used:
+            # Build config objects from legacy kwargs, using dataclass defaults for unset values.
+            transcription_fields = {k: v for k, v in legacy_used.items()
+                                    if k in ('whisper_model', 'compute_type', 'device',
+                                             'asr_options', 'vad_options', 'preprocess_options')}
+            translation_fields = {k: v for k, v in legacy_used.items()
+                                  if k in ('chatbot_model', 'fee_limit', 'consumer_thread', 'proxy',
+                                           'base_url_config', 'glossary', 'retry_model',
+                                           'is_force_glossary_used')}
+            transcription = TranscriptionConfig(**transcription_fields)
+            translation = TranslationConfig(**translation_fields)
+
+        self._transcription_config = transcription or TranscriptionConfig()
+        self._translation_config = translation or TranslationConfig()
+
+        # Translation state
+        self.chatbot_model = self._translation_config.chatbot_model
+        self.fee_limit = self._translation_config.fee_limit
         self.api_fee = 0  # Can be updated in different thread, operation should be thread-safe
         self.from_video = set()
-        self.proxy = proxy
-        self.base_url_config = base_url_config
-        self.glossary = self.parse_glossary(glossary)
-        self.retry_model = retry_model
-        self.is_force_glossary_used = is_force_glossary_used
+        self.proxy = self._translation_config.proxy
+        self.base_url_config = self._translation_config.base_url_config
+        self.glossary = self.parse_glossary(self._translation_config.glossary)
+        self.retry_model = self._translation_config.retry_model
+        self.is_force_glossary_used = self._translation_config.is_force_glossary_used
 
         self._lock = Lock()
         self.exception = None
-        self.consumer_thread = consumer_thread
+        self.consumer_thread = self._translation_config.consumer_thread
 
         # Merge default options with provided options
-        self.asr_options = {**default_asr_options, **(asr_options or {})}
-        self.vad_options = {**default_vad_options, **(vad_options or {})}
-        self.preprocess_options = {**default_preprocess_options, **(preprocess_options or {})}
+        self.asr_options = {**default_asr_options, **(self._transcription_config.asr_options or {})}
+        self.vad_options = {**default_vad_options, **(self._transcription_config.vad_options or {})}
+        self.preprocess_options = {**default_preprocess_options, **(self._transcription_config.preprocess_options or {})}
 
-        self.transcriber = Transcriber(model_name=whisper_model, compute_type=compute_type, device=device,
-                                       asr_options=self.asr_options, vad_options=self.vad_options)
+        # Lazy initialization: Transcriber is created on first access via the property.
+        self._transcriber = None
         self.transcribed_paths = []
+
+    @property
+    def transcriber(self) -> Transcriber:
+        """Lazily initialize and return the Transcriber instance."""
+        if self._transcriber is None:
+            self._transcriber = Transcriber(
+                model_name=self._transcription_config.whisper_model,
+                compute_type=self._transcription_config.compute_type,
+                device=self._transcription_config.device,
+                asr_options=self.asr_options,
+                vad_options=self.vad_options,
+            )
+        return self._transcriber
 
     @staticmethod
     def parse_glossary(glossary: Union[dict, str, Path]):

--- a/tests/test_openlrc.py
+++ b/tests/test_openlrc.py
@@ -3,14 +3,18 @@
 
 import shutil
 import unittest
+import warnings
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from faster_whisper.transcribe import Segment, Word
 
-from openlrc.openlrc import LRCer
+from openlrc.openlrc import LRCer, TranscriptionConfig, TranslationConfig
 from openlrc.transcribe import TranscriptionInfo
 from openlrc.utils import extend_filename
+
+# Shared test config — avoids repeating these in every test method.
+_TEST_TRANSCRIPTION = TranscriptionConfig(whisper_model='tiny', compute_type='default', device='cpu')
 
 
 @patch('openlrc.transcribe.BatchedInferencePipeline', MagicMock())
@@ -54,56 +58,60 @@ class TestLRCer(unittest.TestCase):
 
         shutil.rmtree('data/preprocessed', ignore_errors=True)
 
+    # ------------------------------------------------------------------
+    # Pipeline tests (using new config API)
+    # ------------------------------------------------------------------
+
     @patch('openlrc.translate.LLMTranslator.translate',
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_single_audio_transcription_translation(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run(self.audio_path)
         self.assertTrue(result)
 
     @patch('openlrc.translate.LLMTranslator.translate',
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_multiple_audio_transcription_translation(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run([self.audio_path, self.video_path])
         self.assertTrue(result)
         self.assertEqual(len(result), 2)
 
     def test_audio_file_not_found(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         with self.assertRaises(FileNotFoundError):
             lrcer.run('data/invalid.mp3')
 
     @patch('openlrc.translate.LLMTranslator.translate',
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_video_file_transcription_translation(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run('data/test_video.mp4')
         self.assertTrue(result)
 
     @patch('openlrc.translate.LLMTranslator.translate',
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_nospeech_video_file_transcription_translation(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run('data/test_nospeech_video.mp4')
         self.assertTrue(result)
 
     @patch('openlrc.translate.LLMTranslator.translate', MagicMock(side_effect=Exception('test exception')))
     def test_translation_error(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         with self.assertRaises(Exception):
             lrcer.run(self.audio_path)
 
     @patch('openlrc.translate.LLMTranslator.translate', MagicMock(side_effect=Exception('test exception')))
     def test_skip_translation(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run('data/test_video.mp4', skip_trans=True)
         self.assertTrue(result)
 
     @patch('openlrc.translate.LLMTranslator.translate',
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_skip_preprocess(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
 
         # Stage 1: Run preprocessing only
         lrcer.pre_process([self.audio_path])
@@ -118,7 +126,7 @@ class TestLRCer(unittest.TestCase):
         self.assertTrue(result)
 
     def test_skip_preprocess_file_not_found(self):
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
 
         # Ensure no preprocessed file exists
         from openlrc.utils import get_preprocessed_path
@@ -133,7 +141,7 @@ class TestLRCer(unittest.TestCase):
     @patch('openlrc.openlrc.LRCer.post_process', wraps=LRCer.post_process)
     def test_skip_trans_skips_translate_but_calls_post_process(self, mock_post_process, mock_translate):
         """skip_trans=True should skip translation but still post-process transcription."""
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         lrcer.run(self.audio_path, skip_trans=True)
         mock_translate.assert_not_called()
         mock_post_process.assert_called()
@@ -142,14 +150,14 @@ class TestLRCer(unittest.TestCase):
     def test_normal_run_calls_translate(self, mock_translate):
         """skip_trans=False (default) should invoke LLMTranslator.translate."""
         mock_translate.return_value = ['test translation1', 'test translation2']
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         lrcer.run(self.audio_path)
         mock_translate.assert_called()
 
     @patch('openlrc.translate.LLMTranslator.translate')
     def test_transcribe_returns_json_paths(self, mock_translate):
         """transcribe() should return transcribed JSON paths without triggering translation."""
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.transcribe(self.audio_path)
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0].exists())
@@ -160,7 +168,7 @@ class TestLRCer(unittest.TestCase):
     def test_translate_processes_transcribed_json(self, mock_translate):
         """translate() should process transcribed JSON files and produce subtitle output."""
         mock_translate.return_value = ['test translation1', 'test translation2']
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
 
         # Stage 1: transcribe to get JSON paths
         transcribed = lrcer.transcribe(self.audio_path)
@@ -177,11 +185,11 @@ class TestLRCer(unittest.TestCase):
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_translate_independent_video_transcription_outputs_srt(self):
         """translate() should keep video-origin output as .srt even on a fresh LRCer."""
-        lrcer_transcribe = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer_transcribe = LRCer(transcription=_TEST_TRANSCRIPTION)
         transcribed = lrcer_transcribe.transcribe(self.video_path)
         self.assertEqual(len(transcribed), 1)
 
-        lrcer_translate = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer_translate = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer_translate.translate(transcribed, target_lang='zh-cn')
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].suffix, '.srt')
@@ -189,7 +197,7 @@ class TestLRCer(unittest.TestCase):
     @patch('openlrc.translate.LLMTranslator.translate')
     def test_run_skip_trans_deduplicates_duplicate_inputs(self, mock_translate):
         """run(skip_trans=True) should transcribe duplicate input paths only once."""
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run([self.audio_path, self.audio_path], skip_trans=True)
         self.assertTrue(result)
         self.assertEqual(len(result), 1)
@@ -199,7 +207,103 @@ class TestLRCer(unittest.TestCase):
            MagicMock(return_value=['test translation1', 'test translation2']))
     def test_run_full_pipeline(self):
         """run() with default args should produce subtitle output (full pipeline)."""
-        lrcer = LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
         result = lrcer.run(self.audio_path)
         self.assertTrue(result)
         self.assertEqual(len(result), 1)
+
+    # ------------------------------------------------------------------
+    # Config and constructor tests
+    # ------------------------------------------------------------------
+
+    def test_translate_only_does_not_instantiate_transcriber(self):
+        """LRCer with only TranslationConfig should not create a Transcriber."""
+        lrcer = LRCer(translation=TranslationConfig())
+        # Access the private attribute directly — should be None (lazy init).
+        self.assertIsNone(lrcer._transcriber)
+
+    @patch('openlrc.translate.LLMTranslator.translate',
+           MagicMock(return_value=['test translation1', 'test translation2']))
+    def test_transcriber_created_on_first_transcribe_call(self):
+        """Transcriber should be lazily created when transcribe() is first called."""
+        lrcer = LRCer(transcription=_TEST_TRANSCRIPTION)
+        self.assertIsNone(lrcer._transcriber)
+        lrcer.transcribe(self.audio_path)
+        self.assertIsNotNone(lrcer._transcriber)
+
+    def test_default_option_merging_parity(self):
+        """Config-based construction should merge default options the same as legacy kwargs."""
+        from openlrc.defaults import default_asr_options, default_vad_options, default_preprocess_options
+
+        custom_asr = {'beam_size': 3}
+        custom_vad = {'threshold': 0.7}
+        custom_preprocess = {'atten_lim_db': 20}
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            legacy = LRCer(whisper_model='tiny', device='cpu', compute_type='default',
+                           asr_options=custom_asr, vad_options=custom_vad,
+                           preprocess_options=custom_preprocess)
+
+        config_based = LRCer(
+            transcription=TranscriptionConfig(
+                whisper_model='tiny', device='cpu', compute_type='default',
+                asr_options=custom_asr, vad_options=custom_vad,
+                preprocess_options=custom_preprocess,
+            ),
+        )
+
+        self.assertEqual(legacy.asr_options, config_based.asr_options)
+        self.assertEqual(legacy.vad_options, config_based.vad_options)
+        self.assertEqual(legacy.preprocess_options, config_based.preprocess_options)
+
+        # Verify custom values are merged on top of defaults
+        self.assertEqual(config_based.asr_options['beam_size'], 3)
+        self.assertEqual(config_based.asr_options['best_of'], default_asr_options['best_of'])
+        self.assertEqual(config_based.vad_options['threshold'], 0.7)
+        self.assertEqual(config_based.preprocess_options['atten_lim_db'], 20)
+
+    def test_legacy_and_config_equivalent_runtime_behavior(self):
+        """Legacy kwargs and config objects should produce equivalent LRCer state."""
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            legacy = LRCer(whisper_model='tiny', device='cpu', compute_type='default',
+                           chatbot_model='gpt-4.1-nano', fee_limit=1.5, consumer_thread=2)
+
+        config_based = LRCer(
+            transcription=TranscriptionConfig(whisper_model='tiny', device='cpu', compute_type='default'),
+            translation=TranslationConfig(chatbot_model='gpt-4.1-nano', fee_limit=1.5, consumer_thread=2),
+        )
+
+        # Transcription config
+        self.assertEqual(legacy._transcription_config.whisper_model,
+                         config_based._transcription_config.whisper_model)
+        self.assertEqual(legacy._transcription_config.device,
+                         config_based._transcription_config.device)
+        self.assertEqual(legacy._transcription_config.compute_type,
+                         config_based._transcription_config.compute_type)
+
+        # Translation config
+        self.assertEqual(legacy.chatbot_model, config_based.chatbot_model)
+        self.assertEqual(legacy.fee_limit, config_based.fee_limit)
+        self.assertEqual(legacy.consumer_thread, config_based.consumer_thread)
+
+    def test_legacy_kwargs_emit_deprecation_warning(self):
+        """Legacy keyword arguments should emit a DeprecationWarning."""
+        with self.assertWarns(DeprecationWarning):
+            LRCer(whisper_model='tiny', device='cpu', compute_type='default')
+
+    def test_mixing_legacy_and_config_raises_error(self):
+        """Passing both legacy kwargs and config objects should raise ValueError."""
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            with self.assertRaises(ValueError):
+                LRCer(whisper_model='tiny',
+                      transcription=TranscriptionConfig(whisper_model='tiny'))
+
+    def test_default_construction_without_arguments(self):
+        """LRCer() with no arguments should use default configs."""
+        lrcer = LRCer()
+        self.assertEqual(lrcer._transcription_config.whisper_model, 'large-v3')
+        self.assertEqual(lrcer._translation_config.chatbot_model, 'gpt-4.1-nano')
+        self.assertIsNone(lrcer._transcriber)


### PR DESCRIPTION
Implementation for issue #81: decouple LRCer constructor into structured config objects.

### Changes

- Add `TranscriptionConfig` and `TranslationConfig` dataclasses
- Refactor `LRCer.__init__` to accept config objects as preferred API
- Legacy kwargs still supported with `DeprecationWarning`, mixing raises `ValueError`
- Lazy-initialize `Transcriber` via `@property` (translate-only workflows skip model loading)
- Migrate `gui_streamlit/home.py` to new config API
- Export new classes from `openlrc/__init__.py`

### New tests (7)

- Lazy init: `_transcriber` is `None` until first transcribe call
- Option merging parity: legacy and config paths produce identical merged options
- Constructor equivalence: legacy and config paths produce equivalent runtime state
- Deprecation warning on legacy kwargs
- `ValueError` on mixing legacy kwargs with config objects
- Default construction without arguments

### Usage

```python
# New (preferred)
lrcer = LRCer(
    transcription=TranscriptionConfig(whisper_model='large-v3', device='cuda'),
    translation=TranslationConfig(chatbot_model='gpt-4.1-nano', fee_limit=1.0),
)

# Legacy (deprecated, will be removed in future major version)
lrcer = LRCer(whisper_model='large-v3', chatbot_model='gpt-4.1-nano')