### PR TITLE
chore: fix bugs and code hygiene issues

### DIFF
--- a/openlrc/__init__.py
+++ b/openlrc/__init__.py
@@ -5,5 +5,5 @@ from openlrc.models import ModelConfig, ModelProvider, list_chatbot_models
 from openlrc.openlrc import LRCer, TranscriptionConfig, TranslationConfig
 
 __all__ = ("LRCer", "TranscriptionConfig", "TranslationConfig", "ModelConfig", "list_chatbot_models", "ModelProvider")
-__version__ = "1.5.2"
+__version__ = "1.6.1"
 __author__ = "zh-plus"

--- a/openlrc/agents.py
+++ b/openlrc/agents.py
@@ -100,7 +100,7 @@ class ChunkedTranslatorAgent(Agent):
         self,
         src_lang,
         target_lang,
-        info: TranslateInfo = TranslateInfo(),
+        info: TranslateInfo | None = None,
         chatbot_model: str | ModelConfig = "gpt-4.1-nano",
         fee_limit: float = 0.8,
         proxy: str | None = None,
@@ -119,6 +119,8 @@ class ChunkedTranslatorAgent(Agent):
             base_url_config (Optional[dict]): Configuration for the base URL of the API.
         """
         super().__init__()
+        if info is None:
+            info = TranslateInfo()
         self.chatbot_model = chatbot_model
         self.info = info
         self.chatbot = self._initialize_chatbot(chatbot_model, fee_limit, proxy, base_url_config)
@@ -149,9 +151,9 @@ class ChunkedTranslatorAgent(Agent):
             translations = self._extract_translations(content)
 
             return [t.strip() for t in translations], summary.strip(), scene.strip()
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to extract contents from response: {content}")
-            raise e
+            raise
 
     def _extract_tag_content(self, content: str, tag: str) -> str:
         """
@@ -203,7 +205,7 @@ class ChunkedTranslatorAgent(Agent):
         self,
         chunk_id: int,
         chunk: list[tuple[int, str]],
-        context: TranslationContext = TranslationContext(),
+        context: TranslationContext | None = None,
         use_glossary: bool = True,
     ) -> tuple[list[str], TranslationContext]:
         """
@@ -218,6 +220,8 @@ class ChunkedTranslatorAgent(Agent):
         Returns:
             Tuple[List[str], TranslationContext]: The translated texts and updated context.
         """
+        if context is None:
+            context = TranslationContext()
         user_input = self.prompter.format_texts(chunk)
         guideline = context.guideline if use_glossary else context.non_glossary_guideline
         messages_list = [
@@ -251,7 +255,7 @@ class ContextReviewerAgent(Agent):
         self,
         src_lang,
         target_lang,
-        info: TranslateInfo = TranslateInfo(),
+        info: TranslateInfo | None = None,
         chatbot_model: str | ModelConfig = "gpt-4.1-nano",
         retry_model: str | ModelConfig | None = None,
         fee_limit: float = 0.8,
@@ -272,6 +276,8 @@ class ContextReviewerAgent(Agent):
             base_url_config (Optional[dict]): Configuration for the base URL of the API.
         """
         super().__init__()
+        if info is None:
+            info = TranslateInfo()
         self.src_lang = src_lang
         self.target_lang = target_lang
         self.info = info
@@ -426,7 +432,7 @@ class ProofreaderAgent(Agent):
         self,
         src_lang,
         target_lang,
-        info: TranslateInfo = TranslateInfo(),
+        info: TranslateInfo | None = None,
         chatbot_model: str | ModelConfig = "gpt-4.1-nano",
         fee_limit: float = 0.8,
         proxy: str | None = None,
@@ -445,6 +451,8 @@ class ProofreaderAgent(Agent):
             base_url_config (Optional[dict]): Configuration for the base URL of the API.
         """
         super().__init__()
+        if info is None:
+            info = TranslateInfo()
         self.src_lang = src_lang
         self.target_lang = target_lang
         self.info = info

--- a/openlrc/chatbot.py
+++ b/openlrc/chatbot.py
@@ -6,7 +6,6 @@ import json
 import os
 import random
 import re
-import time
 from collections.abc import Callable
 from copy import deepcopy
 
@@ -80,7 +79,7 @@ class ChatBot:
             self.model_info = Models.get_model(model_name, beta)
             self.model_name = model_name
         except ValueError:
-            raise ValueError(f"Invalid model {model_name}.")
+            raise ValueError(f"Invalid model {model_name}.") from None
 
         self.temperature = temperature
         self.top_p = top_p
@@ -175,7 +174,7 @@ class ChatBot:
             )
         except ChatBotException as e:
             logger.error(f"Failed to message with GPT. Error: {e}")
-            raise e
+            raise
         finally:
             logger.info(f"Translation fee for this call: {self.api_fees[-1]:.4f} USD")
             logger.info(f"Total bot translation fee: {sum(self.api_fees):.4f} USD")
@@ -257,6 +256,9 @@ class GPTBot(ChatBot):
 
         raise ValueError("No API key found. Set OPENAI_API_KEY or pass api_key explicitly.")
 
+    def __enter__(self):
+        return self
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         asyncio.run(self.async_client.close())
 
@@ -318,7 +320,7 @@ class GPTBot(ChatBot):
             ) as e:
                 sleep_time = self._get_sleep_time(e)
                 logger.warning(f"{type(e).__name__}: {e}. Wait {sleep_time}s before retry. Retry num: {i + 1}.")
-                time.sleep(sleep_time)
+                await asyncio.sleep(sleep_time)
 
         if not response:
             raise ChatBotException("Failed to create a chat.")
@@ -424,7 +426,7 @@ class ClaudeBot(ChatBot):
             ) as e:
                 sleep_time = self._get_sleep_time(e)
                 logger.warning(f"{type(e).__name__}: {e}. Wait {sleep_time}s before retry. Retry num: {i + 1}.")
-                time.sleep(sleep_time)
+                await asyncio.sleep(sleep_time)
 
         if not response:
             raise ChatBotException("Failed to create a chat.")
@@ -552,7 +554,7 @@ class GeminiBot(ChatBot):
             self.update_fee(response)
             if not response.text:
                 logger.warning(f"Get None response. Wait 15s. Retry num: {i + 1}.")
-                time.sleep(15)
+                await asyncio.sleep(15)
                 continue
 
             response_text = remove_stop(response.text, stop_sequences)

--- a/openlrc/logger.py
+++ b/openlrc/logger.py
@@ -17,8 +17,9 @@ formatter = ColoredFormatter(
 )
 handler.setFormatter(formatter)
 
-logger = logging.getLogger()
+logger = logging.getLogger("openlrc")
 logger.handlers.clear()  # Clear existing handlers
 logger.addHandler(handler)
+logger.propagate = False
 
 logger.setLevel("INFO")

--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -679,7 +679,7 @@ class LRCer:
             logger.warning("No audio/video file given. Skip LRCer.run()")
             return []
 
-        if isinstance(paths, str) or isinstance(paths, Path):
+        if isinstance(paths, (str, Path)):
             paths = [paths]
 
         paths = list(map(Path, paths))
@@ -743,7 +743,7 @@ class LRCer:
 
         This method removes temporary folders and generated wave files from video processing.
         """
-        temp_folders = set([path.parent for path in paths])
+        temp_folders = {path.parent for path in paths}
         for folder in temp_folders:
             assert folder.name == "preprocessed", f"Not a temporary folder: {folder}"
 

--- a/openlrc/preprocess.py
+++ b/openlrc/preprocess.py
@@ -43,8 +43,10 @@ class Preprocessor:
         self,
         audio_paths: str | Path | list[str] | list[Path],
         output_folder: str = "preprocessed",
-        options: dict = default_preprocess_options,
+        options: dict | None = None,
     ):
+        if options is None:
+            options = dict(default_preprocess_options)
         paths_list = audio_paths if isinstance(audio_paths, list) else [audio_paths]
         self.audio_paths: list[Path] = [Path(p) for p in paths_list]
         self.output_paths = [p.parent / output_folder for p in self.audio_paths]
@@ -61,7 +63,7 @@ class Preprocessor:
         if not audio_paths:
             return []
 
-        if "atten_lim_db" in self.options.keys():
+        if "atten_lim_db" in self.options:
             atten_lim_db = self.options["atten_lim_db"]
 
         model, df_state, _ = init_df()

--- a/openlrc/subtitle.py
+++ b/openlrc/subtitle.py
@@ -60,6 +60,8 @@ class Subtitle:
             return Subtitle.from_lrc(filename)
         elif suffix == ".srt":
             return Subtitle.from_srt(filename)
+        else:
+            raise ValueError(f"Unsupported subtitle format: {suffix!r}")
 
     def __len__(self):
         return len(self.segments)

--- a/openlrc/transcribe.py
+++ b/openlrc/transcribe.py
@@ -148,7 +148,7 @@ class Transcriber:
         Returns:
             list: List of sentence-split segments.
         """
-        if lang not in LANGUAGE_CODES.keys():
+        if lang not in LANGUAGE_CODES:
             logger.warning(f"Language {lang} not supported. Skipping sentence split.")
             return segments
 

--- a/openlrc/translate.py
+++ b/openlrc/translate.py
@@ -162,7 +162,7 @@ class LLMTranslator(Translator):
         texts: str | list[str],
         src_lang: str,
         target_lang: str,
-        info: TranslateInfo = TranslateInfo(),
+        info: TranslateInfo | None = None,
         compare_path: Path = Path("translate_intermediate.json"),
     ) -> list[str]:
         """
@@ -185,6 +185,9 @@ class LLMTranslator(Translator):
         Returns:
             List[str]: List of translated texts.
         """
+        if info is None:
+            info = TranslateInfo()
+
         if not isinstance(texts, list):
             texts = [texts]
 
@@ -414,7 +417,7 @@ class MSTranslator(Translator):
         try:
             request = requests.post(self.constructed_url, params=params, headers=self.headers, json=body, timeout=20)
         except TimeoutError:
-            raise RuntimeError("Failed to connect to Microsoft Translator API.")
+            raise RuntimeError("Failed to connect to Microsoft Translator API.") from None
         response = request.json()
 
         return json.dumps(response, sort_keys=True, ensure_ascii=False, indent=4, separators=(",", ": "))

--- a/openlrc/utils.py
+++ b/openlrc/utils.py
@@ -310,24 +310,24 @@ def get_similarity(text1, text2):
 
 
 def merge_subtitle(video_path, subtitle_path, output_path):
-    def convert2ffmpeg_path(path):
-        abs_path = str(Path(path).absolute()).replace("\\", "/")
-
-        abs_path = abs_path[0] + "\\\\" + abs_path[1:]
-
-        return abs_path
-
     # check ffmpeg
     try:
-        subprocess.check_output("ffmpeg -version", shell=True)
+        subprocess.check_output(["ffmpeg", "-version"])
     except FileNotFoundError:
-        raise RuntimeError("ffmpeg is not installed. Please install ffmpeg first.")
+        raise RuntimeError("ffmpeg is not installed. Please install ffmpeg first.") from None
 
-    subtitle_path = convert2ffmpeg_path(subtitle_path)
+    subtitle_abs = str(Path(subtitle_path).absolute())
     style = "FontSize=24,Bold=1"
     subprocess.call(
-        f'ffmpeg -y -i "{video_path}" -vf subtitles="{subtitle_path}":force_style=\'{style}\' "{output_path}"',
-        shell=True,
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
+            "-vf",
+            f"subtitles={subtitle_abs}:force_style='{style}'",
+            str(output_path),
+        ]
     )
 
     logger.info(f"Subtitled video saved to {output_path}")


### PR DESCRIPTION
## Fix bugs and code hygiene

### Bug fixes

**Blocking `time.sleep()` in async retry loop (chatbot.py)**

`_create_achat` is an async method called concurrently via `asyncio.gather` to translate multiple chunks in parallel. The retry backoff used `time.sleep()`, which blocks the entire event loop and effectively serializes all concurrent translation requests during the wait. Replaced with `await asyncio.sleep()` so other coroutines can proceed while waiting.

**Silent failure on unsupported subtitle format (subtitle.py)**

`Subtitle.from_file()` only handled `.srt` and `.lrc` suffixes. For any other format, the method silently returned `None`, causing confusing errors downstream. Added an explicit `raise ValueError` for unsupported formats so the problem is caught immediately.

**Mutable default argument shared across instances (preprocess.py)**

`Preprocessor.__init__` used `options: dict = default_preprocess_options`, meaning all instances shared the same dict object. If any instance modified `self.options`, it would affect all subsequent instances and the module-level default itself. Changed to `None` default with a `dict()` copy in the body.

### Code hygiene

- **Sync `__version__`** in `__init__.py` with `pyproject.toml` (`"1.6.1"`)
- **Add `__enter__`** to `GPTBot` to pair with the existing `__exit__`, making it a proper context manager
- **`raise e` → bare `raise`** to preserve the original traceback (chatbot.py, agents.py)
- **Add `from None`** to raise-in-except blocks for cleaner exception chains (chatbot.py, translate.py, utils.py)
- **Named logger**: `logging.getLogger()` → `logging.getLogger("openlrc")` with `propagate = False` to avoid polluting the root logger (logger.py)
- **Remove `shell=True`** from subprocess calls in `merge_subtitle()`, using list-based arguments instead (utils.py)
- **Fix mutable default arguments**: `TranslateInfo()` / `TranslationContext()` as default parameter values → `None` with fallback in body (agents.py, translate.py)
- **Minor style**: merge `isinstance` calls, use set comprehension, drop redundant `.keys()` (openlrc.py, transcribe.py, preprocess.py)