### PR TITLE
chore: correct typos in variable names, comments, and prompts

### DIFF
--- a/openlrc/agents.py
+++ b/openlrc/agents.py
@@ -375,7 +375,7 @@ class ContextReviewerAgent(Agent):
 
             if not validated:
                 for i in range(2, 4):
-                    logger.warning(f"Retry to generate the context using {self.chatbot} at {i} reties.")
+                    logger.warning(f"Retry to generate the context using {self.chatbot} at {i} retries.")
                     resp = self.chatbot.message(
                         messages_list,
                         stop_sequences=[self.prompter.stop_sequence],

--- a/openlrc/evaluate.py
+++ b/openlrc/evaluate.py
@@ -26,10 +26,10 @@ class LLMTranslationEvaluator(TranslationEvaluator):
     """
 
     def __init__(self, chatbot_model: str | ModelConfig = "gpt-4.1-nano"):
-        self.agenet = TranslationEvaluatorAgent(chatbot_model=chatbot_model)
+        self.agent = TranslationEvaluatorAgent(chatbot_model=chatbot_model)
 
     def evaluate(self, src_texts, target_texts, src_lang=None, target_lang=None):
-        return self.agenet.evaluate(src_texts, target_texts)
+        return self.agent.evaluate(src_texts, target_texts)
 
 
 class EmbeddingTranslationEvaluator(TranslationEvaluator):

--- a/openlrc/preprocess.py
+++ b/openlrc/preprocess.py
@@ -58,7 +58,7 @@ class Preprocessor:
 
     def noise_suppression(self, audio_paths: list[Path], atten_lim_db: int = 15):
         """
-        Supress noise in audio.
+        Suppress noise in audio.
         """
         if not audio_paths:
             return []

--- a/openlrc/prompter.py
+++ b/openlrc/prompter.py
@@ -146,7 +146,7 @@ class ChunkedTranslatePrompter(TranslatePrompter):
         self.user_prompt = f"""Translation guidelines from context reviewer:
 {{guideline}}
 
-Previews summaries:
+Previous summaries:
 {{summaries_str}}
 
 <chunk_id> Scene 1 Chunk {{chunk_num}} <chunk_id>

--- a/openlrc/utils.py
+++ b/openlrc/utils.py
@@ -116,13 +116,13 @@ def normalize(text):
     """
     Normalize strings using str.lower(), and unicodedata.normalize
     """
-    # unicodedata cant handel quotes as expected'’'
+    # unicodedata can't handle quotes as expected'’'
     quotes_table = str.maketrans("〈〉゛“”‘’", '<>"""\'\'')
     text = text.translate(quotes_table)
 
     text = unicodedata.normalize("NFKC", text.lower())
 
-    # unicodedata cant handel kana
+    # unicodedata can't handle kana
     text = jaconvV2.z2h(text)
 
     # Special case

--- a/tests/test_prompter.py
+++ b/tests/test_prompter.py
@@ -9,7 +9,7 @@ from openlrc.prompter import ChunkedTranslatePrompter, Prompter
 formatted_user_input = """Translation guidelines from context reviewer:
 This is a guidline.
 
-Previews summaries:
+Previous summaries:
 Chunk 1: test chunk1 summary
 Chunk 2: test chunk2 summary
 


### PR DESCRIPTION
## Fix typos in variable names, comments, and prompts

### Functional impact

- **`evaluate.py`**: `self.agenet` → `self.agent` — fixes a misspelled attribute name that would break if the class is ever refactored or type-checked
- **`prompter.py`**: `Previews summaries` → `Previous summaries` — this text is sent to the LLM as part of the translation prompt, the typo could subtly affect translation quality

### Comments only

- **`preprocess.py`**: `Supress` → `Suppress`
- **`agents.py`**: `reties` → `retries`
- **`utils.py`**: `handel` → `handle`, `cant` → `can't`