### PR TITLE
chore: add cpu/cu124 extras for PyTorch index selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,10 @@ jobs:
         uses: FedericoCarboni/setup-ffmpeg@v2
         id: setup-ffmpeg
 
+      - name: Install dependencies (CPU-only PyTorch for CI)
+        run: uv sync --extra cpu
+
       - name: Test with unittest
         working-directory: ./tests
         run: |
-          uv run python -m unittest discover -s . -p 'test_*.py'
+          uv run --extra cpu python -m unittest discover -s . -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -77,12 +77,52 @@ into `.lrc` subtitles with LLMs such as
 
 ## Installation ⚙️
 
-1. Install CUDA 11.x and [cuDNN 8 for CUDA 11](https://developer.nvidia.com/cudnn) first according
-   to https://opennmt.net/CTranslate2/installation.html to enable `faster-whisper`.
+1. Add LLM API keys (recommended for most users: `OPENROUTER_API_KEY`):
+   - Add your [OpenAI API key](https://platform.openai.com/account/api-keys) to environment variable `OPENAI_API_KEY`.
+   - Add your [Anthropic API key](https://console.anthropic.com/settings/keys) to environment variable
+     `ANTHROPIC_API_KEY`.
+   - Add your [Google API Key](https://aistudio.google.com/app/apikey) to environment variable `GOOGLE_API_KEY`.
+   - Add your [OpenRouter API key](https://openrouter.ai/keys) to environment variable `OPENROUTER_API_KEY`.
 
-   `faster-whisper` also needs [cuBLAS for CUDA 11](https://developer.nvidia.com/cublas) installed.
+2. Install [ffmpeg](https://ffmpeg.org/download.html) and add `bin` directory
+   to your `PATH`.
+
+3. Install from PyPI:
+
+   ```shell
+   pip install openlrc
+   ```
+
+   By default this installs the GPU-enabled PyTorch from PyPI (same as upstream PyTorch behavior).
+   To explicitly install a CPU-only or CUDA 12.4 build, use an extra:
+
+   ```shell
+   pip install openlrc[cpu]      # CPU-only (smaller download, no GPU required)
+   pip install openlrc[cu124]    # CUDA 12.4 (explicit GPU build from PyTorch index)
+   ```
+
+   Or install directly from GitHub:
+
+   ```shell
+   pip install git+https://github.com/zh-plus/openlrc
+   ```
+
+4. Install the latest [faster-whisper](https://github.com/guillaumekln/faster-whisper) from source:
+   ```shell
+   pip install "faster-whisper @ https://github.com/SYSTRAN/faster-whisper/archive/8327d8cc647266ed66f6cd878cf97eccface7351.tar.gz"
+   ```
+
    <details>
-   <summary>For Windows Users (click to expand)</summary> 
+   <summary>For GPU users: CUDA runtime requirements (click to expand)</summary>
+
+   Running with GPU acceleration requires the
+   [CUDA 12 Toolkit](https://developer.nvidia.com/cuda-toolkit) (provides `libcudart`, `libcublas`, etc.).
+   If you installed PyTorch with `openlrc[cu124]` or the default GPU build from PyPI, make sure the
+   CUDA 12 runtime libraries are available on your system.
+
+   Additionally, `faster-whisper` requires
+   [cuDNN 9 for CUDA 12](https://developer.nvidia.com/cudnn) to run on GPU.
+   See the [CTranslate2 documentation](https://opennmt.net/CTranslate2/installation.html) for details.
 
    (Windows only) You can download the libraries from Purfview's repository:
 
@@ -92,43 +132,37 @@ into `.lrc` subtitles with LLMs such as
 
    </details>
 
+### Using openlrc as a dependency
 
-2. Add LLM API keys (recommended for most users: `OPENROUTER_API_KEY`):
-   - Add your [OpenAI API key](https://platform.openai.com/account/api-keys) to environment variable `OPENAI_API_KEY`.
-   - Add your [Anthropic API key](https://console.anthropic.com/settings/keys) to environment variable
-     `ANTHROPIC_API_KEY`.
-   - Add your [Google API Key](https://aistudio.google.com/app/apikey) to environment variable `GOOGLE_API_KEY`.
-   - Add your [OpenRouter API key](https://openrouter.ai/keys) to environment variable `OPENROUTER_API_KEY`.
+If your project depends on openlrc and you want to switch between CPU and GPU
+PyTorch builds (e.g. CPU for development/CI, GPU for production),
+map openlrc's extras through your own `pyproject.toml`:
 
-3. Install [ffmpeg](https://ffmpeg.org/download.html) and add `bin` directory
-   to your `PATH`.
+```toml
+[project]
+dependencies = [
+    "openlrc",
+]
 
-4. This project can be installed from PyPI:
+[project.optional-dependencies]
+cpu = ["openlrc[cpu]"]
+cu124 = ["openlrc[cu124]"]
 
-    ```shell
-    pip install openlrc
-    ```
+[tool.uv]
+conflicts = [
+    [{ extra = "cpu" }, { extra = "cu124" }],
+]
+```
 
-   or install directly from GitHub:
+Then select the variant at install time:
 
-    ```shell
-    pip install git+https://github.com/zh-plus/openlrc
-    ```
+```shell
+# Local development (CPU)
+uv sync --extra cpu
 
-5. Install the latest [faster-whisper](https://github.com/guillaumekln/faster-whisper) from source:
-   ```shell
-   pip install "faster-whisper @ https://github.com/SYSTRAN/faster-whisper/archive/8327d8cc647266ed66f6cd878cf97eccface7351.tar.gz"
-   ```
-
-6. Install [PyTorch](https://pytorch.org/get-started/locally/):
-   ```shell
-   pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
-   ```
-
-7. Fix the `typing-extensions` issue:
-   ```shell
-   pip install typing-extensions -U
-   ```
+# Production with GPU
+uv sync --extra cu124
+```
 
 ## Usage 🐍
 
@@ -303,7 +337,15 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 
 ```shell
 uv venv
+
+# Default (GPU-enabled PyTorch from PyPI)
 uv sync
+
+# CPU-only (for CI, or machines without GPU)
+uv sync --extra cpu
+
+# CUDA 12.4 (explicit GPU build from PyTorch index)
+uv sync --extra cu124
 ```
 
 ### Code quality checks

--- a/openlrc/preprocess.py
+++ b/openlrc/preprocess.py
@@ -4,8 +4,6 @@ import logging
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
-import torch
-from df.enhance import enhance, init_df, load_audio, save_audio
 from ffmpeg_normalize import FFmpegNormalize
 from tqdm import tqdm
 
@@ -60,6 +58,11 @@ class Preprocessor:
         """
         Suppress noise in audio.
         """
+        # Lazy import: torch and deepfilternet are heavy dependencies that may not be available
+        # in all environments (e.g. CI with CPU-only PyTorch). Only import when actually needed.
+        import torch
+        from df.enhance import enhance, init_df, load_audio, save_audio
+
         if not audio_paths:
             return []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,19 @@ dependencies = [
     "torch>=2.6.0",
     "torchvision>=0.21.0",
     "torchaudio>=2.0.0",
-    "pip>=25.1"
+    "pip>=25.1",
+]
+
+[project.optional-dependencies]
+cpu = [
+    "torch>=2.6.0",
+    "torchvision>=0.21.0",
+    "torchaudio>=2.0.0",
+]
+cu124 = [
+    "torch>=2.6.0",
+    "torchvision>=0.21.0",
+    "torchaudio>=2.0.0",
 ]
 
 [project.urls]
@@ -77,11 +89,19 @@ dev = [
 ]
 
 [tool.uv]
+conflicts = [
+    [{ extra = "cpu" }, { extra = "cu124" }],
+]
 
 [[tool.uv.index]]
 name = "PyPI"
 url = "https://pypi.org/simple/"
 default = true
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cu124"
@@ -91,13 +111,16 @@ explicit = true
 [tool.uv.sources]
 faster-whisper = { url = "https://github.com/SYSTRAN/faster-whisper/archive/8327d8cc647266ed66f6cd878cf97eccface7351.tar.gz" }
 torch = [
-    { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu124", extra = "cu124" },
 ]
 torchvision = [
-    { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu124", extra = "cu124" },
 ]
 torchaudio = [
-    { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu124", extra = "cu124" },
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Add cpu/cu124 extras for PyTorch index selection

### Summary

Add optional extras (`cpu`, `cu124`) that allow users and CI to override which PyTorch index is used, while keeping the default behavior unchanged.

### Motivation

CI environments typically cannot install the full CUDA PyTorch stack, which blocks running pyright for type checking. With this change, CI can use `uv sync --extra cpu` to install a lightweight CPU-only PyTorch and run type checks cleanly.

### Behavior

| Command | PyTorch version installed |
|---|---|
| `pip install openlrc` | Default from PyPI (GPU-enabled on Linux, same as before) |
| `uv sync` | Default from PyPI (GPU-enabled on Linux, same as before) |
| `uv sync --extra cpu` | CPU-only build from `pytorch-cpu` index |
| `uv sync --extra cu124` | CUDA 12.4 build from `pytorch-cu124` index |

This is **not** a breaking change. `pip install openlrc` and `uv sync` without extras behave exactly as before.

### Downstream usage

If your project depends on openlrc and you want to switch between CPU and GPU PyTorch builds (e.g. CPU for development/CI, GPU for production), map openlrc's extras through your own `pyproject.toml`:

```toml
[project]
dependencies = [
    "openlrc",
]

[project.optional-dependencies]
cpu = ["openlrc[cpu]"]
cu124 = ["openlrc[cu124]"]

[tool.uv]
conflicts = [
    [{ extra = "cpu" }, { extra = "cu124" }],
]
```

Then select the variant at install time:

```shell
uv sync --extra cpu       # development / CI
uv sync --extra cu124     # production with GPU
```

### What changed

- `pyproject.toml`: added `cpu` and `cu124` optional-dependencies, both listing `torch`, `torchvision`, `torchaudio` (these packages remain in core `dependencies` as well)
- Added `pytorch-cpu` index alongside the existing `pytorch-cu124` index
- Added `[tool.uv]` conflicts to prevent both extras from being enabled simultaneously
- Updated `[tool.uv.sources]` to route each extra to its corresponding PyTorch index
- Updated README installation instructions and added downstream usage guide