### PR TITLE
Drop Python 3.9 support and remove unused torchvision uv source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "openlrc"
 version = "1.6.2"
 description = "Transcribe (whisper) and translate (gpt) voice into LRC file."
 authors = [{ name = "Hao Zheng", email = "zhenghaosustc@gmail.com" }]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.10, <3.13"
 readme = "README.md"
 license = "MIT"
 keywords = ["openai-gpt3", "whisper", "voice transcribe", "lrc"]
@@ -79,9 +79,6 @@ explicit = true
 
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-torchvision = [
     { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 torchaudio = [


### PR DESCRIPTION
## Summary

- Raise `requires-python` minimum from `3.9` to `3.10`.
- Remove `torchvision` from `[tool.uv.sources]`.

### Drop Python 3.9

Python 3.9 reached end-of-life in October 2025 and no longer receives security patches. The CI matrix already does not test Python 3.9 (only 3.10/3.11/3.12), so 3.9 support has been effectively untested for some time.

### Remove torchvision uv source

`torchvision` is not declared anywhere in `dependencies` or `[project.optional-dependencies]`, and no source file in the project imports it. The entry in `[tool.uv.sources]` was likely added by mistake when configuring the PyTorch index for `torch` and `torchaudio`.