### PR TITLE
fix: skip retries for deterministic client errors

### DIFF
--- a/openlrc/chatbot.py
+++ b/openlrc/chatbot.py
@@ -312,6 +312,16 @@ class GPTBot(ChatBot):
                 # Authentication errors are deterministic and should not be retried.
                 raise ChatBotException(f"Authentication failed: {e}") from e
             except (
+                openai.BadRequestError,
+                openai.NotFoundError,
+                openai.PermissionDeniedError,
+                openai.ConflictError,
+                openai.UnprocessableEntityError,
+            ) as e:
+                # Client errors are deterministic (e.g. context window exceeded, invalid model),
+                # retrying will not change the outcome.
+                raise ChatBotException(f"Client error: {e}") from e
+            except (
                 openai.RateLimitError,
                 openai.APITimeoutError,
                 openai.APIConnectionError,
@@ -418,6 +428,19 @@ class ClaudeBot(ChatBot):
                     continue
 
                 break
+            except anthropic.AuthenticationError as e:
+                # Authentication errors are deterministic and should not be retried.
+                raise ChatBotException(f"Authentication failed: {e}") from e
+            except (
+                anthropic.BadRequestError,
+                anthropic.NotFoundError,
+                anthropic.PermissionDeniedError,
+                anthropic.ConflictError,
+                anthropic.UnprocessableEntityError,
+            ) as e:
+                # Client errors are deterministic (e.g. context window exceeded, invalid model),
+                # retrying will not change the outcome.
+                raise ChatBotException(f"Client error: {e}") from e
             except (
                 anthropic.RateLimitError,
                 anthropic.APITimeoutError,


### PR DESCRIPTION
## Problem

When the LLM API returns deterministic client errors (e.g. context window exceeded, invalid model, permission denied), openlrc retries 4 times with 15s sleep each, wasting 60 seconds before finally failing. These errors will never succeed on retry.

## Fix

Add early-exit `except` blocks for deterministic client errors in both `GPTBot` and `ClaudeBot`:

- `BadRequestError` (400) - e.g. context window exceeded
- `AuthenticationError` (401) - invalid API key (ClaudeBot was missing this)
- `PermissionDeniedError` (403)
- `NotFoundError` (404) - e.g. invalid model name
- `ConflictError` (409)
- `UnprocessableEntityError` (422)

Transient errors (`RateLimitError`, `APITimeoutError`, `APIConnectionError`, `InternalServerError`) still retry as before.

## Changes

- `GPTBot._create_achat`: add 5 client error types to no-retry block
- `ClaudeBot._create_achat`: add `AuthenticationError` + 5 client error types to no-retry block