### PR TITLE
fix: dynamically compute max_tokens, allow ModelConfig to override mo…

### DIFF
--- a/openlrc/agents.py
+++ b/openlrc/agents.py
@@ -71,7 +71,7 @@ class Agent(abc.ABC):
                     base_url_config = None
                     logger.warning(f"Unsupported base_url configuration for provider: {chatbot_model.provider}")
 
-            return chatbot_cls(
+            bot = chatbot_cls(
                 model_name=chatbot_model.name,
                 fee_limit=fee_limit,
                 proxy=proxy,
@@ -80,6 +80,19 @@ class Agent(abc.ABC):
                 base_url_config=base_url_config,
                 api_key=chatbot_model.api_key,
             )
+
+            # Override model_info with user-specified capability parameters.
+            # Copy first to avoid mutating the shared registry instance.
+            if chatbot_model.context_window is not None or chatbot_model.max_tokens is not None:
+                from copy import copy
+
+                bot.model_info = copy(bot.model_info)
+                if chatbot_model.context_window is not None:
+                    bot.model_info.context_window = chatbot_model.context_window
+                if chatbot_model.max_tokens is not None:
+                    bot.model_info.max_tokens = chatbot_model.max_tokens
+
+            return bot
         else:
             raise ValueError(f"Invalid chatbot model type: {type(chatbot_model)}. Expected str or ModelConfig.")
 

--- a/openlrc/chatbot.py
+++ b/openlrc/chatbot.py
@@ -89,6 +89,28 @@ class ChatBot:
 
         self.api_fees = []
 
+    def _compute_max_tokens(self, messages: list[dict]) -> int:
+        """Dynamically compute max_tokens based on input size and model context window.
+
+        Prevents context window overflow by capping output tokens to the remaining
+        space after input tokens, with a 5% safety margin for tokenizer estimation error.
+        Returns at least 1024 to avoid overly truncated output.
+        """
+        input_tokens = get_messages_token_number(messages)
+        context_window = self.model_info.context_window
+        model_max = self.model_info.max_tokens
+
+        available = int(context_window * 0.95) - input_tokens
+        computed = min(model_max, max(available, 1024))
+
+        if computed < model_max:
+            logger.info(
+                f"Dynamic max_tokens: {computed} "
+                f"(input={input_tokens}, context_window={context_window}, model_max={model_max})"
+            )
+
+        return computed
+
     def estimate_fee(self, messages: list[dict]):
         """
         Estimate the total fee for the given messages.
@@ -295,7 +317,7 @@ class GPTBot(ChatBot):
                     top_p=self.top_p,
                     response_format={"type": "json_object" if self.json_mode else "text"},  # pyright: ignore[reportArgumentType]
                     stop=stop_sequences,
-                    max_tokens=self.model_info.max_tokens,
+                    max_tokens=self._compute_max_tokens(messages),
                 )
                 self.update_fee(response)
                 if response.choices[0].finish_reason == "length":
@@ -399,6 +421,9 @@ class ClaudeBot(ChatBot):
     ):
         # No need to check stop sequences for Claude (unlimited)
 
+        # Compute max_tokens before popping system message from the list.
+        max_tokens = self._compute_max_tokens(messages)
+
         # Move "system" role into the parameters
         system_msg = NOT_GIVEN
         if messages[0]["role"] == "system":
@@ -414,7 +439,7 @@ class ClaudeBot(ChatBot):
                     temperature=self.temperature,
                     top_p=self.top_p,
                     stop_sequences=stop_sequences or NOT_GIVEN,
-                    max_tokens=self.model_info.max_tokens,
+                    max_tokens=max_tokens,
                 )
                 self.update_fee(response)
 

--- a/openlrc/models.py
+++ b/openlrc/models.py
@@ -17,12 +17,22 @@ class ModelConfig:
     """
     Configuration for a specific model.
 
+    Combines identity, connection, and capability parameters into a single
+    config object.  Capability fields (``context_window``, ``max_tokens``)
+    are optional: when set they override the values from the built-in model
+    registry, which is useful for self-hosted or custom models whose
+    capabilities differ from the defaults.
+
     Attributes:
         provider (ModelProvider): The provider of the model.
         name (str): The name of the model.
         base_url (Optional[str]): The base URL for the model API.
         api_key (Optional[str]): The API key for authentication.
         proxy (Optional[str]): The proxy server to use for requests.
+        context_window (Optional[int]): Total context window size in tokens.
+            Overrides the built-in default when set.
+        max_tokens (Optional[int]): Maximum output tokens per request.
+            Overrides the built-in default when set.
     """
 
     provider: ModelProvider
@@ -30,6 +40,8 @@ class ModelConfig:
     base_url: str | None = None
     api_key: str | None = None
     proxy: str | None = None
+    context_window: int | None = None
+    max_tokens: int | None = None
 
     def __str__(self):
         return f"{self.provider.value}:{self.name}"


### PR DESCRIPTION
## Motivation

When input tokens are large relative to the model's context window, vLLM pre-allocates KV cache space based on `max_tokens` and rejects the request if `input_tokens + max_tokens > context_window`. openlrc hardcodes `max_tokens` to the model's maximum output capacity (e.g. 4096), even when the actual output needs far less (e.g. ~1000 tokens for guideline generation). This causes unnecessary 400 errors on long subtitle files.

Additionally, self-hosted models running on limited GPU memory often have smaller context windows than the built-in defaults. These models fall back to `DefaultThirdPartyModelInfo(context_window=32768)`, which is inaccurate. There was no way for users to specify the correct context_window or max_tokens for custom models.

## Industry approaches

The core problem — allowing users to specify model capabilities for custom or self-hosted models — is well-solved in mature LLM frameworks:

**LiteLLM** uses a two-layer config per model entry: `litellm_params` for connection details (api_base, api_key, model) and `model_info` for capability metadata (max_tokens, context_window, cost). When a model isn't in LiteLLM's built-in cost map, users provide `model_info` to fill in the gaps. User-specified values always take precedence over built-in defaults. This is the closest analogy to openlrc's situation — a built-in registry of known models, with an escape hatch for custom deployments.

```yaml
# LiteLLM config.yaml
model_list:
  - model_name: my-custom-model
    litellm_params:
      model: openai/my-custom-model
      api_base: https://my-server.com
    model_info:
      max_tokens: 4096
      context_window: 16384
```

**LangChain** takes a flatter approach: all parameters — connection, capabilities, and generation settings — are constructor arguments on the model class itself. `max_tokens`, `temperature`, `base_url`, and `api_key` all live at the same level. There is no separate registry; the user is always in control of every parameter.

```python
# LangChain
llm = ChatOpenAI(
    model="my-custom-model",
    base_url="https://my-server.com",
    max_tokens=4096,
)
```

Both frameworks share the same principle: **the built-in model registry provides sensible defaults, but users can always override capability parameters for models the registry doesn't know about.** This PR applies the same principle to openlrc's `ModelConfig`.

## Changes

**`chatbot.py`** - Add `ChatBot._compute_max_tokens()`:
- Dynamically computes `min(model_max, max(context_window * 0.95 - input_tokens, 1024))`
- Short inputs: uses model default (no behavior change)
- Long inputs: shrinks max_tokens to fit context window
- Applied to `GPTBot._create_achat` and `ClaudeBot._create_achat`

**`models.py`** - Extend `ModelConfig` with optional capability fields:
- `context_window: int | None` - overrides built-in default when set
- `max_tokens: int | None` - overrides built-in default when set
- Existing callers unaffected (both default to `None`)

**`agents.py`** - Apply `ModelConfig` overrides in `_initialize_chatbot`:
- When `context_window` or `max_tokens` is set, copies `model_info` before mutating to avoid corrupting the shared registry instance

## Backward compatibility

Fully backward compatible. Existing code paths are unchanged when the new fields are not set. The only observable difference: requests that previously failed with 400 (context window exceeded) may now succeed.