### PR TITLE
refactor: externalize ChatBot lifecycle from Agents to callers

### DIFF
--- a/openlrc/agents.py
+++ b/openlrc/agents.py
@@ -6,7 +6,7 @@ import re
 
 from json_repair import repair_json
 
-from openlrc.chatbot import ClaudeBot, GeminiBot, GPTBot, provider2chatbot, route_chatbot
+from openlrc.chatbot import ChatBot, ClaudeBot, GeminiBot, GPTBot, provider2chatbot, route_chatbot
 from openlrc.context import TranslateInfo, TranslationContext
 from openlrc.logger import logger
 from openlrc.models import ModelConfig, ModelProvider
@@ -22,6 +22,61 @@ from openlrc.utils import get_text_token_number
 from openlrc.validators import POTENTIAL_PREFIX_COMBOS
 
 
+def create_chatbot(
+    chatbot_model: str | ModelConfig,
+    fee_limit: float = 0.8,
+    proxy: str | None = None,
+    base_url_config: dict | None = None,
+) -> ChatBot:
+    """Create a ChatBot instance from a model name or ModelConfig.
+
+    The caller is responsible for closing the returned ChatBot when done
+    (via ``close()`` or a ``with`` statement).
+    """
+    if isinstance(chatbot_model, str):
+        chatbot_cls: type[ClaudeBot] | type[GPTBot] | type[GeminiBot]
+        chatbot_cls, model_name = route_chatbot(chatbot_model)
+        return chatbot_cls(
+            model_name=model_name, fee_limit=fee_limit, proxy=proxy, retry=4, base_url_config=base_url_config
+        )
+    elif isinstance(chatbot_model, ModelConfig):
+        chatbot_cls = provider2chatbot[chatbot_model.provider]
+        proxy = chatbot_model.proxy or proxy
+
+        if chatbot_model.base_url:
+            if chatbot_model.provider == ModelProvider.OPENAI:
+                base_url_config = {"openai": chatbot_model.base_url}
+            elif chatbot_model.provider == ModelProvider.ANTHROPIC:
+                base_url_config = {"anthropic": chatbot_model.base_url}
+            else:
+                base_url_config = None
+                logger.warning(f"Unsupported base_url configuration for provider: {chatbot_model.provider}")
+
+        bot = chatbot_cls(
+            model_name=chatbot_model.name,
+            fee_limit=fee_limit,
+            proxy=proxy,
+            retry=4,
+            base_url_config=base_url_config,
+            api_key=chatbot_model.api_key,
+        )
+
+        # Override model_info with user-specified capability parameters.
+        # Copy first to avoid mutating the shared registry instance.
+        if chatbot_model.context_window is not None or chatbot_model.max_tokens is not None:
+            from copy import copy
+
+            bot.model_info = copy(bot.model_info)
+            if chatbot_model.context_window is not None:
+                bot.model_info.context_window = chatbot_model.context_window
+            if chatbot_model.max_tokens is not None:
+                bot.model_info.max_tokens = chatbot_model.max_tokens
+
+        return bot
+    else:
+        raise ValueError(f"Invalid chatbot model type: {type(chatbot_model)}. Expected str or ModelConfig.")
+
+
 class Agent(abc.ABC):
     """
     Base class for all agents.
@@ -31,71 +86,6 @@ class Agent(abc.ABC):
     """
 
     TEMPERATURE = 1
-
-    def _initialize_chatbot(
-        self, chatbot_model: str | ModelConfig, fee_limit: float, proxy: str | None, base_url_config: dict | None
-    ) -> ClaudeBot | GPTBot | GeminiBot:
-        """
-        Initialize a chatbot instance based on the provided parameters.
-
-        Args:
-            chatbot_model (Union[str, ModelConfig]): The name of the chatbot model or ModelConfig.
-            fee_limit (float): The maximum fee allowed for API calls.
-            proxy (str): Proxy server to use for API calls.
-            base_url_config (Optional[dict]): Configuration for the base URL of the API.
-
-        Returns:
-            Union[ClaudeBot, GPTBot]: An instance of the appropriate chatbot class.
-        """
-
-        if isinstance(chatbot_model, str):
-            chatbot_cls: type[ClaudeBot] | type[GPTBot] | type[GeminiBot]
-            chatbot_cls, model_name = route_chatbot(chatbot_model)
-            return chatbot_cls(
-                model_name=model_name,
-                fee_limit=fee_limit,
-                proxy=proxy,
-                retry=4,
-                temperature=self.TEMPERATURE,
-                base_url_config=base_url_config,
-            )
-        elif isinstance(chatbot_model, ModelConfig):
-            chatbot_cls = provider2chatbot[chatbot_model.provider]
-            proxy = chatbot_model.proxy or proxy
-
-            if chatbot_model.base_url:
-                if chatbot_model.provider == ModelProvider.OPENAI:
-                    base_url_config = {"openai": chatbot_model.base_url}
-                elif chatbot_model.provider == ModelProvider.ANTHROPIC:
-                    base_url_config = {"anthropic": chatbot_model.base_url}
-                else:
-                    base_url_config = None
-                    logger.warning(f"Unsupported base_url configuration for provider: {chatbot_model.provider}")
-
-            bot = chatbot_cls(
-                model_name=chatbot_model.name,
-                fee_limit=fee_limit,
-                proxy=proxy,
-                retry=4,
-                temperature=self.TEMPERATURE,
-                base_url_config=base_url_config,
-                api_key=chatbot_model.api_key,
-            )
-
-            # Override model_info with user-specified capability parameters.
-            # Copy first to avoid mutating the shared registry instance.
-            if chatbot_model.context_window is not None or chatbot_model.max_tokens is not None:
-                from copy import copy
-
-                bot.model_info = copy(bot.model_info)
-                if chatbot_model.context_window is not None:
-                    bot.model_info.context_window = chatbot_model.context_window
-                if chatbot_model.max_tokens is not None:
-                    bot.model_info.max_tokens = chatbot_model.max_tokens
-
-            return bot
-        else:
-            raise ValueError(f"Invalid chatbot model type: {type(chatbot_model)}. Expected str or ModelConfig.")
 
 
 class ChunkedTranslatorAgent(Agent):
@@ -110,34 +100,22 @@ class ChunkedTranslatorAgent(Agent):
 
     TEMPERATURE = 1.0
 
-    def __init__(
-        self,
-        src_lang,
-        target_lang,
-        info: TranslateInfo | None = None,
-        chatbot_model: str | ModelConfig = "gpt-4.1-nano",
-        fee_limit: float = 0.8,
-        proxy: str | None = None,
-        base_url_config: dict | None = None,
-    ):
+    def __init__(self, src_lang: str, target_lang: str, info: TranslateInfo | None = None, *, chatbot: ChatBot):
         """
         Initialize the ChunkedTranslatorAgent.
 
         Args:
-            src_lang (str): The source language.
-            target_lang (str): The target language for translation.
-            info (TranslateInfo): Additional translation information.
-            chatbot_model (Union[str, ModelConfig]): The name of the chatbot model or ModelConfig.
-            fee_limit (float): The maximum fee allowed for API calls.
-            proxy (str): Proxy server to use for API calls.
-            base_url_config (Optional[dict]): Configuration for the base URL of the API.
+            src_lang: The source language.
+            target_lang: The target language for translation.
+            info: Additional translation information.
+            chatbot: ChatBot instance to use for LLM calls.
         """
         super().__init__()
         if info is None:
             info = TranslateInfo()
-        self.chatbot_model = chatbot_model
         self.info = info
-        self.chatbot = self._initialize_chatbot(chatbot_model, fee_limit, proxy, base_url_config)
+        self.chatbot = chatbot
+        self.chatbot_model = chatbot.model_name
         self.prompter = ChunkedTranslatePrompter(src_lang, target_lang, info)
         self.cost = 0
 
@@ -245,7 +223,9 @@ class ChunkedTranslatorAgent(Agent):
                 "content": self.prompter.user(chunk_id, user_input, context.previous_summaries or "", guideline or ""),
             },
         ]
-        resp = self.chatbot.message(messages_list, output_checker=self.prompter.check_format)[0]
+        resp = self.chatbot.message(
+            messages_list, output_checker=self.prompter.check_format, temperature=self.TEMPERATURE
+        )[0]
         translations, summary, scene = self._parse_responses(resp)
         self.cost += self.chatbot.api_fees[-1]
         context.update(summary=summary, scene=scene, model=self.chatbot_model)
@@ -271,29 +251,24 @@ class ContextReviewerAgent(Agent):
 
     def __init__(
         self,
-        src_lang,
-        target_lang,
+        src_lang: str,
+        target_lang: str,
         info: TranslateInfo | None = None,
-        chatbot_model: str | ModelConfig = "gpt-4.1-nano",
-        retry_model: str | ModelConfig | None = None,
-        fee_limit: float = 0.8,
-        proxy: str | None = None,
-        base_url_config: dict | None = None,
+        *,
+        chatbot: ChatBot,
+        retry_chatbot: ChatBot | None = None,
         chunked_guideline: bool = False,
     ):
         """
         Initialize the ContextReviewerAgent.
 
         Args:
-            src_lang (str): The source language.
-            target_lang (str): The target language.
-            info (TranslateInfo): Additional translation information.
-            chatbot_model (Union[str, ModelConfig]): The name or ModelConfig of the primary chatbot model.
-            retry_model (Union[str, ModelConfig]): The name or ModelConfig of the backup chatbot model to use for retries.
-            fee_limit (float): The maximum fee allowed for API calls.
-            proxy (str): Proxy server to use for API calls.
-            base_url_config (Optional[dict]): Configuration for the base URL of the API.
-            chunked_guideline (bool): Enable chunked guideline generation for long texts.
+            src_lang: The source language.
+            target_lang: The target language.
+            info: Additional translation information.
+            chatbot: ChatBot instance to use for LLM calls.
+            retry_chatbot: Optional ChatBot instance for retry attempts.
+            chunked_guideline: Enable chunked guideline generation for long texts.
                 When False (default), long texts that exceed the context window will fail.
                 When True, automatically splits into chunks and merges partial guidelines.
         """
@@ -303,14 +278,12 @@ class ContextReviewerAgent(Agent):
         self.src_lang = src_lang
         self.target_lang = target_lang
         self.info = info
-        self.chatbot_model = chatbot_model
+        self.chatbot = chatbot
+        self.chatbot_model = chatbot.model_name
         self.chunked_guideline = chunked_guideline
         self.validate_prompter = ContextReviewerValidatePrompter()
         self.prompter = ContextReviewPrompter(src_lang, target_lang)
-        self.chatbot = self._initialize_chatbot(chatbot_model, fee_limit, proxy, base_url_config)
-        self.retry_chatbot = (
-            self._initialize_chatbot(retry_model, fee_limit, proxy, base_url_config) if retry_model else None
-        )
+        self.retry_chatbot = retry_chatbot
 
     def __str__(self):
         return f"Context Reviewer Agent ({self.chatbot_model})"
@@ -342,6 +315,7 @@ class ContextReviewerAgent(Agent):
             messages_list,
             stop_sequences=[self.prompter.stop_sequence],
             output_checker=self.validate_prompter.check_format,
+            temperature=self.TEMPERATURE,
         )[0]
         content = self.chatbot.get_content(resp)
         return bool(content and "true" in content.lower())
@@ -375,9 +349,7 @@ class ContextReviewerAgent(Agent):
                 context = self._build_context_single(text_content, title, glossary)
             except Exception as e:
                 if self.chunked_guideline:
-                    logger.warning(
-                        f"Single-pass guideline failed ({e}), falling back to chunked generation."
-                    )
+                    logger.warning(f"Single-pass guideline failed ({e}), falling back to chunked generation.")
                     context = self._build_context_chunked(texts, title, glossary)
                 else:
                     logger.error(
@@ -387,8 +359,7 @@ class ContextReviewerAgent(Agent):
                     raise
         elif self.chunked_guideline:
             logger.info(
-                f"Input too large for single pass (available_output={available_output}), "
-                f"splitting into chunks."
+                f"Input too large for single pass (available_output={available_output}), splitting into chunks."
             )
             context = self._build_context_chunked(texts, title, glossary)
         else:
@@ -423,6 +394,7 @@ class ContextReviewerAgent(Agent):
                     messages_list,
                     stop_sequences=[self.prompter.stop_sequence],
                     output_checker=self.prompter.check_format,
+                    temperature=self.TEMPERATURE,
                 )[0]
                 content = bot.get_content(resp)
                 if content:
@@ -528,11 +500,7 @@ class ContextReviewerAgent(Agent):
                 {
                     "role": "user",
                     "content": self.prompter.user_partial(
-                        chunk_text,
-                        chunk_index=i + 1,
-                        total_chunks=len(chunks),
-                        title=title,
-                        given_glossary=glossary,
+                        chunk_text, chunk_index=i + 1, total_chunks=len(chunks), title=title, given_glossary=glossary
                     ),
                 },
             ]
@@ -541,6 +509,7 @@ class ContextReviewerAgent(Agent):
                     messages,
                     stop_sequences=[self.prompter.stop_sequence],
                     output_checker=self.prompter.check_format,
+                    temperature=self.TEMPERATURE,
                 )[0]
                 content = self.chatbot.get_content(resp)
                 if content:
@@ -583,8 +552,7 @@ class ContextReviewerAgent(Agent):
 
         # Too large: split into pairs and merge hierarchically.
         logger.info(
-            f"Merge input too large ({user_tokens} tokens), "
-            f"merging hierarchically ({len(guidelines)} guidelines)."
+            f"Merge input too large ({user_tokens} tokens), merging hierarchically ({len(guidelines)} guidelines)."
         )
         merged: list[str] = []
         for i in range(0, len(guidelines), 2):
@@ -615,6 +583,7 @@ class ContextReviewerAgent(Agent):
                     merge_messages,
                     stop_sequences=[self.prompter.stop_sequence],
                     output_checker=self.prompter.check_format,
+                    temperature=self.TEMPERATURE,
                 )[0]
                 content = self.chatbot.get_content(resp)
                 if content:
@@ -658,27 +627,15 @@ class ProofreaderAgent(Agent):
 
     TEMPERATURE = 0.8
 
-    def __init__(
-        self,
-        src_lang,
-        target_lang,
-        info: TranslateInfo | None = None,
-        chatbot_model: str | ModelConfig = "gpt-4.1-nano",
-        fee_limit: float = 0.8,
-        proxy: str | None = None,
-        base_url_config: dict | None = None,
-    ):
+    def __init__(self, src_lang: str, target_lang: str, info: TranslateInfo | None = None, *, chatbot: ChatBot):
         """
         Initialize the ProofreaderAgent.
 
         Args:
-            src_lang (str): The source language.
-            target_lang (str): The target language.
-            info (TranslateInfo): Additional translation information.
-            chatbot_model (Union[str, ModelConfig]): The name or ModelConfig of the chatbot model to use.
-            fee_limit (float): The maximum fee allowed for API calls.
-            proxy (str): Proxy server to use for API calls.
-            base_url_config (Optional[dict]): Configuration for the base URL of the API.
+            src_lang: The source language.
+            target_lang: The target language.
+            info: Additional translation information.
+            chatbot: ChatBot instance to use for LLM calls.
         """
         super().__init__()
         if info is None:
@@ -687,7 +644,7 @@ class ProofreaderAgent(Agent):
         self.target_lang = target_lang
         self.info = info
         self.prompter = ProofreaderPrompter(src_lang, target_lang)
-        self.chatbot = self._initialize_chatbot(chatbot_model, fee_limit, proxy, base_url_config)
+        self.chatbot = chatbot
 
     def _parse_responses(self, resp) -> list[str]:
         """
@@ -723,7 +680,9 @@ class ProofreaderAgent(Agent):
             {"role": "system", "content": self.prompter.system()},
             {"role": "user", "content": self.prompter.user(texts, translations, context.guideline or "")},
         ]
-        resp = self.chatbot.message(messages_list, output_checker=self.prompter.check_format)[0]
+        resp = self.chatbot.message(
+            messages_list, output_checker=self.prompter.check_format, temperature=self.TEMPERATURE
+        )[0]
         revised = self._parse_responses(resp)
         return revised
 
@@ -741,24 +700,15 @@ class TranslationEvaluatorAgent(Agent):
 
     TEMPERATURE = 0.95
 
-    def __init__(
-        self,
-        chatbot_model: str | ModelConfig = "gpt-4.1-nano",
-        fee_limit: float = 0.8,
-        proxy: str | None = None,
-        base_url_config: dict | None = None,
-    ):
+    def __init__(self, *, chatbot: ChatBot):
         """
         Initialize the TranslationEvaluatorAgent.
 
         Args:
-            chatbot_model (Union[str, ModelConfig]): The name of the chatbot model or ModelConfig.
-            fee_limit (float): The maximum fee allowed for API calls.
-            proxy (str): Proxy server to use for API calls.
-            base_url_config (Optional[dict]): Configuration for the base URL of the API.
+            chatbot: ChatBot instance to use for LLM calls.
         """
         super().__init__()
-        self.chatbot = self._initialize_chatbot(chatbot_model, fee_limit, proxy, base_url_config)
+        self.chatbot = chatbot
         self.prompter = TranslationEvaluatorPrompter()
 
     def evaluate(self, src_texts: list[str], target_texts: list[str]) -> dict:
@@ -784,7 +734,9 @@ class TranslationEvaluatorAgent(Agent):
             {"role": "system", "content": self.prompter.system()},
             {"role": "user", "content": self.prompter.user(src_texts, target_texts)},
         ]
-        resp = self.chatbot.message(messages_list, stop_sequences=[self.prompter.stop_sequence])[0]
+        resp = self.chatbot.message(
+            messages_list, stop_sequences=[self.prompter.stop_sequence], temperature=self.TEMPERATURE
+        )[0]
         content = self.chatbot.get_content(resp)
 
         # Repair potentially broken JSON

--- a/openlrc/evaluate.py
+++ b/openlrc/evaluate.py
@@ -2,7 +2,7 @@
 #  All rights reserved.
 import abc
 
-from openlrc.agents import TranslationEvaluatorAgent
+from openlrc.agents import TranslationEvaluatorAgent, create_chatbot
 from openlrc.models import ModelConfig
 
 
@@ -26,10 +26,21 @@ class LLMTranslationEvaluator(TranslationEvaluator):
     """
 
     def __init__(self, chatbot_model: str | ModelConfig = "gpt-4.1-nano"):
-        self.agent = TranslationEvaluatorAgent(chatbot_model=chatbot_model)
+        self._chatbot = create_chatbot(chatbot_model)
+        self.agent = TranslationEvaluatorAgent(chatbot=self._chatbot)
 
     def evaluate(self, src_texts, target_texts, src_lang=None, target_lang=None):
         return self.agent.evaluate(src_texts, target_texts)
+
+    def close(self):
+        """Close the underlying chatbot connection."""
+        self._chatbot.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
 
 
 class EmbeddingTranslationEvaluator(TranslationEvaluator):

--- a/openlrc/translate.py
+++ b/openlrc/translate.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 import requests
 
-from openlrc.agents import ChunkedTranslatorAgent, ContextReviewerAgent
+from openlrc.agents import ChunkedTranslatorAgent, ContextReviewerAgent, create_chatbot
+from openlrc.chatbot import ChatBot
 from openlrc.context import TranslateInfo, TranslationContext
 from openlrc.exceptions import ChatBotException
 from openlrc.logger import logger
@@ -194,74 +195,76 @@ class LLMTranslator(Translator):
         if not isinstance(texts, list):
             texts = [texts]
 
-        translator_agent = ChunkedTranslatorAgent(
-            src_lang, target_lang, info, self.chatbot_model, self.fee_limit, self.proxy, self.base_url_config
-        )
-
-        retry_agent = (
-            ChunkedTranslatorAgent(
-                src_lang, target_lang, info, self.retry_model, self.fee_limit, self.proxy, self.base_url_config
-            )
+        chatbot = create_chatbot(self.chatbot_model, self.fee_limit, self.proxy, self.base_url_config)
+        retry_bot = (
+            create_chatbot(self.retry_model, self.fee_limit, self.proxy, self.base_url_config)
             if self.retry_model
             else None
         )
 
-        # proofreader = ProofreaderAgent(src_lang, target_lang, info, self.chatbot_model, self.fee_limit, self.proxy,
-        #                                self.base_url_config)
+        try:
+            translator_agent = ChunkedTranslatorAgent(src_lang, target_lang, info, chatbot=chatbot)
 
-        chunks = self.make_chunks(texts, chunk_size=self.chunk_size)
-        logger.info(f"Translating {info.title}: {len(chunks)} chunks, {len(texts)} lines in total.")
+            retry_agent = ChunkedTranslatorAgent(src_lang, target_lang, info, chatbot=retry_bot) if retry_bot else None
 
-        translations, summaries, compare_list, start_chunk, guideline = self._resume_translation(compare_path)
-        if not guideline:
-            logger.info("Building translation guideline.")
-            context_reviewer = ContextReviewerAgent(
-                src_lang,
-                target_lang,
-                info,
-                self.chatbot_model,
-                self.retry_model,
-                self.fee_limit,
-                self.proxy,
-                self.base_url_config,
-                chunked_guideline=self.chunked_guideline,
-            )
-            guideline = context_reviewer.build_context(
-                texts, title=info.title or "", glossary=info.glossary, forced_glossary=info.forced_glossary
-            )
-            logger.info(f"Translation Guideline:\n{guideline}")
+            # proofreader = ProofreaderAgent(src_lang, target_lang, info, chatbot=chatbot)
 
-        context = TranslationContext(guideline=guideline, previous_summaries=summaries)
-        for i, chunk in list(enumerate(chunks, start=1))[start_chunk:]:
-            atomic = False
-            translated, context = self._translate_chunk(translator_agent, chunk, context, i, retry_agent=retry_agent)
-            chunk_texts = [c[1] for c in chunk]
-            # Proofreader Not fully tested
-            # localized_trans = proofreader.proofread(
-            #     texts=chunk_texts, translations=translated, context=context
-            # )
+            chunks = self.make_chunks(texts, chunk_size=self.chunk_size)
+            logger.info(f"Translating {info.title}: {len(chunks)} chunks, {len(texts)} lines in total.")
 
-            if len(translated) != len(chunk):
-                logger.warning(
-                    f"Chunk {i} translation length inconsistent: {len(translated)} vs {len(chunk)},"
-                    f" Attempting atomic translation."
+            translations, summaries, compare_list, start_chunk, guideline = self._resume_translation(compare_path)
+            if not guideline:
+                logger.info("Building translation guideline.")
+                context_reviewer = ContextReviewerAgent(
+                    src_lang,
+                    target_lang,
+                    info,
+                    chatbot=chatbot,
+                    retry_chatbot=retry_bot,
+                    chunked_guideline=self.chunked_guideline,
                 )
-                translated = self.atomic_translate(self.chatbot_model, chunk_texts, src_lang, target_lang)
-                atomic = True
+                guideline = context_reviewer.build_context(
+                    texts, title=info.title or "", glossary=info.glossary, forced_glossary=info.forced_glossary
+                )
+                logger.info(f"Translation Guideline:\n{guideline}")
 
-            translations.extend(translated)
-            summaries.append(context.summary or "")
-            logger.info(f"Translated {info.title}: {i}/{len(chunks)}")
-            logger.info(f"Summary: {context.summary}")
-            logger.info(f"Scene: {context.scene}")
+            context = TranslationContext(guideline=guideline, previous_summaries=summaries)
+            for i, chunk in list(enumerate(chunks, start=1))[start_chunk:]:
+                atomic = False
+                translated, context = self._translate_chunk(
+                    translator_agent, chunk, context, i, retry_agent=retry_agent
+                )
+                chunk_texts = [c[1] for c in chunk]
+                # Proofreader Not fully tested
+                # localized_trans = proofreader.proofread(
+                #     texts=chunk_texts, translations=translated, context=context
+                # )
 
-            compare_list.extend(self._generate_compare_list(chunk, translated, i, atomic, context))
-            self._save_intermediate_results(compare_path, compare_list, summaries, context.scene or "", guideline)
-            context.previous_summaries = summaries
+                if len(translated) != len(chunk):
+                    logger.warning(
+                        f"Chunk {i} translation length inconsistent: {len(translated)} vs {len(chunk)},"
+                        f" Attempting atomic translation."
+                    )
+                    translated = self.atomic_translate(chatbot, chunk_texts, src_lang, target_lang)
+                    atomic = True
 
-        self.api_fee += translator_agent.cost + (retry_agent.cost if retry_agent else 0)
+                translations.extend(translated)
+                summaries.append(context.summary or "")
+                logger.info(f"Translated {info.title}: {i}/{len(chunks)}")
+                logger.info(f"Summary: {context.summary}")
+                logger.info(f"Scene: {context.scene}")
 
-        return translations
+                compare_list.extend(self._generate_compare_list(chunk, translated, i, atomic, context))
+                self._save_intermediate_results(compare_path, compare_list, summaries, context.scene or "", guideline)
+                context.previous_summaries = summaries
+
+            self.api_fee += translator_agent.cost + (retry_agent.cost if retry_agent else 0)
+
+            return translations
+        finally:
+            chatbot.close()
+            if retry_bot:
+                retry_bot.close()
 
     def _resume_translation(self, compare_path: Path) -> tuple[list[str], list[str], list[dict], int, str]:
         """
@@ -352,9 +355,7 @@ class LLMTranslator(Translator):
         with open(compare_path, "w", encoding="utf-8") as f:
             json.dump(compare_results, f, indent=4, ensure_ascii=False)
 
-    def atomic_translate(
-        self, chatbot_model: str | ModelConfig, texts: list[str], src_lang: str, target_lang: str
-    ) -> list[str]:
+    def atomic_translate(self, chatbot: ChatBot, texts: list[str], src_lang: str, target_lang: str) -> list[str]:
         """
         Perform atomic translation for each text individually.
 
@@ -362,7 +363,7 @@ class LLMTranslator(Translator):
         each text separately, which can be slower but more reliable for problematic texts.
 
         Args:
-            chatbot_model (Union[str, ModelConfig]): Name or ModelConfig of the chatbot model to use.
+            chatbot (ChatBot): ChatBot instance to use for translation.
             texts (List[str]): List of texts to translate.
             src_lang (str): Source language code.
             target_lang (str): Target language code.
@@ -373,14 +374,12 @@ class LLMTranslator(Translator):
         Raises:
             AssertionError: If the number of translated texts doesn't match the input.
         """
-        chatbot = ChunkedTranslatorAgent(
-            src_lang, target_lang, TranslateInfo(), chatbot_model, self.fee_limit, self.proxy, self.base_url_config
-        ).chatbot
+        from openlrc.agents import ChunkedTranslatorAgent as _CTA
 
         prompter = AtomicTranslatePrompter(src_lang, target_lang)
         message_lists = [[{"role": "user", "content": prompter.user(text)}] for text in texts]
 
-        responses = chatbot.message(message_lists, output_checker=prompter.check_format)
+        responses = chatbot.message(message_lists, output_checker=prompter.check_format, temperature=_CTA.TEMPERATURE)
         self.api_fee += sum(chatbot.api_fees[-(len(texts)) :])
         translated = list(map(chatbot.get_content, responses))
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,7 +11,8 @@ from unittest.mock import MagicMock, patch
 
 from pydantic import BaseModel
 
-from openlrc.agents import ChunkedTranslatorAgent, ContextReviewerAgent, TranslationContext
+from openlrc.agents import ChunkedTranslatorAgent, ContextReviewerAgent, TranslationContext, create_chatbot
+from openlrc.chatbot import GPTBot
 from openlrc.context import TranslateInfo
 from openlrc.models import ModelConfig, ModelProvider
 from openlrc.prompter import ChunkedTranslatePrompter
@@ -58,10 +59,12 @@ class TestTranslatorAgent(unittest.TestCase):
     )
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-dummy"})
     def test_translate_chunk_success(self):
+        bot = GPTBot(api_key="test-dummy")
         agent = ChunkedTranslatorAgent(
             src_lang="en",
             target_lang="fr",
             info=TranslateInfo(title="Example Title", audio_type="Book", glossary={"hello": "bonjour"}),
+            chatbot=bot,
         )
         agent.chatbot.api_fees = [0.00035]
         translations, context = agent.translate_chunk(
@@ -79,7 +82,7 @@ class TestTranslatorAgent(unittest.TestCase):
     #  Handle invalid chatbot model names gracefully
     def test_invalid_chatbot_model(self):
         with self.assertRaises(ValueError):
-            ChunkedTranslatorAgent(src_lang="en", target_lang="fr", info=TranslateInfo(), chatbot_model="invalid-model")
+            create_chatbot("invalid-model")
 
     @patch(
         "openlrc.chatbot.GPTBot.get_content",
@@ -89,7 +92,8 @@ class TestTranslatorAgent(unittest.TestCase):
     )
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-dummy"})
     def test_parse_response_success(self):
-        agent = ChunkedTranslatorAgent(src_lang="en", target_lang="fr")
+        bot = GPTBot(api_key="test-dummy")
+        agent = ChunkedTranslatorAgent(src_lang="en", target_lang="fr", chatbot=bot)
         translations, summary, scene = agent._parse_responses("dummy_response")
 
         self.assertListEqual(translations, ["Bonjour, comment ça va?", "Je vais bien, merci."])
@@ -134,7 +138,8 @@ class TestContextReviewerAgent(unittest.TestCase):
         title = "The Detectors"
         glossary = {"suspect": "嫌疑人", "uptown": "市中心"}
 
-        agent = ContextReviewerAgent("en", "zh", chatbot_model=OPENROUTER_CHEAP_MODEL)
+        bot = create_chatbot(OPENROUTER_CHEAP_MODEL)
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot)
         context = agent.build_context(texts, title, glossary)
 
         self.assertIsNotNone(context)
@@ -192,7 +197,8 @@ class TestContextReviewerChunking(unittest.TestCase):
         """Short text should use single-pass, message called once."""
         mock_message.return_value = [_make_dummy_response(VALID_GUIDELINE)]
 
-        agent = ContextReviewerAgent("en", "zh")
+        bot = GPTBot(api_key="test-dummy")
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot)
         # Large context window: no chunking needed.
         agent.chatbot.model_info.context_window = 100000
         result = agent.build_context(["Hello", "World"], title="Test")
@@ -207,7 +213,8 @@ class TestContextReviewerChunking(unittest.TestCase):
         """When context window is small and chunked_guideline=True, should split and merge."""
         mock_message.return_value = [_make_dummy_response(MERGED_GUIDELINE)]
 
-        agent = ContextReviewerAgent("en", "zh", chunked_guideline=True)
+        bot = GPTBot(api_key="test-dummy")
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot, chunked_guideline=True)
         agent.chatbot.model_info.context_window = 2500
         agent.chatbot.model_info.max_tokens = 1024
         texts = [f"Line {i}: Some subtitle text here that is a bit longer." for i in range(200)]
@@ -223,7 +230,8 @@ class TestContextReviewerChunking(unittest.TestCase):
         """When chunked_guideline=False (default), long text should return empty without calling LLM."""
         mock_message.return_value = [_make_dummy_response(VALID_GUIDELINE)]
 
-        agent = ContextReviewerAgent("en", "zh")
+        bot = GPTBot(api_key="test-dummy")
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot)
         agent.chatbot.model_info.context_window = 2500
         agent.chatbot.model_info.max_tokens = 1024
         texts = [f"Line {i}: Some subtitle text here that is a bit longer." for i in range(200)]
@@ -247,7 +255,8 @@ class TestContextReviewerChunking(unittest.TestCase):
 
         mock_message.side_effect = side_effect_fn
 
-        agent = ContextReviewerAgent("en", "zh", chunked_guideline=True)
+        bot = GPTBot(api_key="test-dummy")
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot, chunked_guideline=True)
         agent.chatbot.model_info.context_window = 2500
         agent.chatbot.model_info.max_tokens = 1024
         texts = [f"Line {i}: Some subtitle text here that is a bit longer." for i in range(200)]
@@ -342,7 +351,8 @@ class TestChunkedGuidelineLive(unittest.TestCase):
 
     def test_baseline_single_pass(self) -> None:
         """Large-window model generates a valid guideline in one pass."""
-        agent = ContextReviewerAgent("en", "zh", chatbot_model=OPENROUTER_CHEAP_MODEL)
+        bot = create_chatbot(OPENROUTER_CHEAP_MODEL)
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot)
 
         t0 = time.monotonic()
         guideline = agent.build_context(self.lines, title=self.title)
@@ -367,7 +377,8 @@ class TestChunkedGuidelineLive(unittest.TestCase):
         model.context_window = 16384
         model.max_tokens = 4096
 
-        agent = ContextReviewerAgent("en", "zh", chatbot_model=model, chunked_guideline=True)
+        bot = create_chatbot(model)
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot, chunked_guideline=True)
 
         t0 = time.monotonic()
         guideline = agent.build_context(self.lines, title=self.title)
@@ -395,7 +406,8 @@ class TestChunkedGuidelineLive(unittest.TestCase):
         model.context_window = 8192
         model.max_tokens = 2048
 
-        agent = ContextReviewerAgent("en", "zh", chatbot_model=model, chunked_guideline=True)
+        bot = create_chatbot(model)
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot, chunked_guideline=True)
 
         t0 = time.monotonic()
         guideline = agent.build_context(self.lines, title=self.title)
@@ -450,7 +462,8 @@ class TestChunkedGuidelineLive(unittest.TestCase):
         results: list[dict] = []
 
         for i in range(runs):
-            agent = ContextReviewerAgent("en", "zh", chatbot_model=model, chunked_guideline=True)
+            bot = create_chatbot(model)
+            agent = ContextReviewerAgent("en", "zh", chatbot=bot, chunked_guideline=True)
             t0 = time.monotonic()
             try:
                 guideline = agent.build_context(self.lines, title=self.title)
@@ -488,7 +501,8 @@ class TestChunkedGuidelineLive(unittest.TestCase):
         model.context_window = 4096
         model.max_tokens = 1024
 
-        agent = ContextReviewerAgent("en", "zh", chatbot_model=model, chunked_guideline=True)
+        bot = create_chatbot(model)
+        agent = ContextReviewerAgent("en", "zh", chatbot=bot, chunked_guideline=True)
 
         t0 = time.monotonic()
         guideline = agent.build_context(self.lines, title=self.title)

--- a/tests/test_llm_translator.py
+++ b/tests/test_llm_translator.py
@@ -66,6 +66,15 @@ class TestMakeChunks(unittest.TestCase):
         self.assertEqual(all_line_numbers, list(range(1, 9)))
 
 
+def _mock_create_chatbot(*args, **kwargs):
+    """Return a lightweight mock ChatBot so translate() can create/close it without real connections."""
+    bot = MagicMock()
+    bot.model_name = "gpt-4.1-nano"
+    bot.close = MagicMock()
+    return bot
+
+
+@patch("openlrc.translate.create_chatbot", side_effect=_mock_create_chatbot)
 @patch.dict(os.environ, {"OPENAI_API_KEY": "test-dummy"})
 class TestLLMTranslatorTranslate(unittest.TestCase):
     """Mock tests for LLMTranslator.translate() — no real API calls."""
@@ -92,7 +101,7 @@ class TestLLMTranslatorTranslate(unittest.TestCase):
 
     @patch("openlrc.translate.ContextReviewerAgent")
     @patch("openlrc.translate.ChunkedTranslatorAgent")
-    def test_single_chunk(self, mock_agent_cls, mock_reviewer_cls):
+    def test_single_chunk(self, mock_agent_cls, mock_reviewer_cls, _mock_chatbot):
         """Texts fitting in one chunk -> translate_chunk called once, correct result."""
         texts = ["hello", "world"]
         expected = ["你好", "世界"]
@@ -115,7 +124,7 @@ class TestLLMTranslatorTranslate(unittest.TestCase):
 
     @patch("openlrc.translate.ContextReviewerAgent")
     @patch("openlrc.translate.ChunkedTranslatorAgent")
-    def test_multiple_chunks(self, mock_agent_cls, mock_reviewer_cls):
+    def test_multiple_chunks(self, mock_agent_cls, mock_reviewer_cls, _mock_chatbot):
         """Texts spanning 2 chunks -> translate_chunk called twice.
 
         With chunk_size=3 and 6 texts, translate() produces 2 chunks.
@@ -145,7 +154,7 @@ class TestLLMTranslatorTranslate(unittest.TestCase):
 
     @patch("openlrc.translate.ContextReviewerAgent")
     @patch("openlrc.translate.ChunkedTranslatorAgent")
-    def test_context_passing_between_chunks(self, mock_agent_cls, mock_reviewer_cls):
+    def test_context_passing_between_chunks(self, mock_agent_cls, mock_reviewer_cls, _mock_chatbot):
         """Context (summary, scene) from chunk N is passed to chunk N+1."""
         texts = [f"text{i}" for i in range(6)]
         call_contexts = []
@@ -180,7 +189,7 @@ class TestLLMTranslatorTranslate(unittest.TestCase):
 
     @patch("openlrc.translate.ContextReviewerAgent")
     @patch("openlrc.translate.ChunkedTranslatorAgent")
-    def test_length_mismatch_triggers_atomic(self, mock_agent_cls, mock_reviewer_cls):
+    def test_length_mismatch_triggers_atomic(self, mock_agent_cls, mock_reviewer_cls, _mock_chatbot):
         """When translate_chunk returns wrong length, atomic_translate is used as fallback."""
         texts = ["hello", "world"]
 
@@ -207,7 +216,7 @@ class TestLLMTranslatorTranslate(unittest.TestCase):
 
     @patch("openlrc.translate.ContextReviewerAgent")
     @patch("openlrc.translate.ChunkedTranslatorAgent")
-    def test_retry_agent_used_on_primary_failure(self, mock_agent_cls, mock_reviewer_cls):
+    def test_retry_agent_used_on_primary_failure(self, mock_agent_cls, mock_reviewer_cls, _mock_chatbot):
         """When primary agent returns wrong length, retry agent is activated."""
         texts = ["hello", "world"]
 
@@ -246,7 +255,7 @@ class TestLLMTranslatorTranslate(unittest.TestCase):
 
     @patch("openlrc.translate.ContextReviewerAgent")
     @patch("openlrc.translate.ChunkedTranslatorAgent")
-    def test_resume_from_compare_file(self, mock_agent_cls, mock_reviewer_cls):
+    def test_resume_from_compare_file(self, mock_agent_cls, mock_reviewer_cls, _mock_chatbot):
         """Translation resumes from saved compare file, skipping already-translated chunks."""
         texts = [f"text{i}" for i in range(6)]
 


### PR DESCRIPTION
## Motivation

This is the second half of the ChatBot lifecycle refactoring (follows PR #107).

PR #107 made `temperature` and `top_p` per-call parameters on `message()`, removing the reason why each Agent needed its own ChatBot instance. This PR completes the refactoring by making Agents receive a pre-created ChatBot instead of creating one internally.

### Before

Each Agent created its own ChatBot in `__init__`, duplicating connection parameters across every constructor:

```
LLMTranslator.translate()
  ├── ContextReviewerAgent(chatbot_model=..., fee_limit=..., proxy=..., base_url_config=...)
  │     ├── chatbot = _initialize_chatbot(...)       # connection pool A
  │     └── retry_chatbot = _initialize_chatbot(...)  # connection pool B
  ├── ChunkedTranslatorAgent(chatbot_model=..., fee_limit=..., proxy=..., base_url_config=...)
  │     └── chatbot = _initialize_chatbot(...)       # connection pool C (same config as A)
  └── atomic_translate() internally
        └── ChunkedTranslatorAgent(...).chatbot       # connection pool D (same config as A)
```

4 connection pools, 3 of which are identical. None explicitly closed.

### After

The caller creates ChatBot instances, passes them to Agents, and closes them when done:

```
LLMTranslator.translate()
  ├── chatbot = create_chatbot(...)                   # connection pool A
  ├── retry_bot = create_chatbot(...)                 # connection pool B
  │
  ├── ContextReviewerAgent(chatbot=chatbot, retry_chatbot=retry_bot, ...)
  ├── ChunkedTranslatorAgent(chatbot=chatbot, ...)
  ├── ChunkedTranslatorAgent(chatbot=retry_bot, ...)
  └── atomic_translate(chatbot, ...)
  │
  └── finally: chatbot.close(), retry_bot.close()
```

2 connection pools, shared across all Agents, explicitly closed.

## Changes

- Extracted `create_chatbot()` as a module-level factory function in `agents.py`. This is the single place where ChatBot instances are created from a model name or `ModelConfig`.
- Removed `Agent._initialize_chatbot()` and all legacy connection parameters (`chatbot_model`, `fee_limit`, `proxy`, `base_url_config`) from Agent constructors. Each Agent now requires a `chatbot: ChatBot` keyword argument.
- `LLMTranslator.translate()` creates ChatBot instances at the top, passes them into all Agents, and closes them in a `finally` block.
- `LLMTranslationEvaluator` manages its own ChatBot lifecycle with `close()` and context manager support.
- All `message()` calls now pass `temperature=self.TEMPERATURE` explicitly, using the per-call temperature support from PR #107.
- Updated all test call sites accordingly.