### PR TITLE
refactor: lazy-init ChatBot at LRCer level, share across files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ into `.lrc` subtitles with LLMs such as
     ```python
 
     from openlrc import ModelConfig, ModelProvider
+    from openlrc.agents import create_chatbot
     from openlrc.translate import LLMTranslator
 
     chatbot_model1 = ModelConfig(
@@ -75,7 +76,9 @@ into `.lrc` subtitles with LLMs such as
         name='gpt-4o-mini', 
         api_key='sk-APIKEY'
     )
-    translator = LLMTranslator(chatbot_model=chatbot_model1, retry_model=chatbot_model2)
+    chatbot = create_chatbot(chatbot_model1)
+    retry_chatbot = create_chatbot(chatbot_model2)
+    translator = LLMTranslator(chatbot=chatbot, retry_chatbot=retry_chatbot)
     ```
 
 ## Installation ⚙️
@@ -229,6 +232,18 @@ if __name__ == '__main__':
     # Bilingual subtitle
     lrcer.run('./data/test.mp3', target_lang='zh-cn', bilingual_sub=True)
 ```
+
+`LRCer` supports the context manager protocol, which automatically closes
+the underlying LLM connections when the block exits:
+
+```python
+with LRCer() as lrcer:
+    lrcer.run(['./data/file1.mp3', './data/file2.mp3'], target_lang='zh-cn')
+# Connections are closed automatically here.
+```
+
+This is recommended when processing multiple files, as the LLM connection
+pool is shared across all files within the same `LRCer` instance.
 
 Check more details in [Documentation](https://zh-plus.github.io/openlrc/#/).
 

--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -166,6 +166,11 @@ class LRCer:
         self._transcriber = None
         self.transcribed_paths = []
 
+        # Lazy initialization: ChatBot instances are created on first access via properties.
+        self._chatbot_lock = Lock()
+        self._chatbot = None
+        self._retry_chatbot = None
+
     @property
     def transcriber(self):
         """Lazily initialize and return the Transcriber instance (thread-safe)."""
@@ -182,6 +187,51 @@ class LRCer:
                         vad_options=self.vad_options,
                     )
         return self._transcriber
+
+    @property
+    def chatbot(self):
+        """Lazily initialize and return the primary ChatBot instance (thread-safe)."""
+        if self._chatbot is None:
+            from openlrc.agents import create_chatbot
+
+            with self._chatbot_lock:
+                if self._chatbot is None:
+                    self._chatbot = create_chatbot(self.chatbot_model, self.fee_limit, self.proxy, self.base_url_config)
+        return self._chatbot
+
+    @property
+    def retry_chatbot(self):
+        """Lazily initialize and return the retry ChatBot instance (thread-safe).
+
+        Returns None if no retry_model is configured.
+        """
+        if self._retry_chatbot is None and self.retry_model:
+            from openlrc.agents import create_chatbot
+
+            with self._chatbot_lock:
+                if self._retry_chatbot is None:
+                    self._retry_chatbot = create_chatbot(
+                        self.retry_model, self.fee_limit, self.proxy, self.base_url_config
+                    )
+        return self._retry_chatbot
+
+    def close(self):
+        """Close ChatBot connections and release resources.
+
+        Safe to call multiple times or before any ChatBot has been created.
+        """
+        if self._chatbot is not None:
+            self._chatbot.close()
+            self._chatbot = None
+        if self._retry_chatbot is not None:
+            self._retry_chatbot.close()
+            self._retry_chatbot = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     @staticmethod
     def parse_glossary(glossary: dict | str | Path | None) -> dict | None:
@@ -526,28 +576,18 @@ class LRCer:
         json_filename = Path(translated_path.parent / (audio_name + ".json"))
         compare_path = Path(translated_path.parent, f"{audio_name}_compare.json")
         if not translated_path.exists():
-            from contextlib import ExitStack
+            translator = LLMTranslator(chatbot=self.chatbot, retry_chatbot=self.retry_chatbot)
 
-            from openlrc.agents import create_chatbot
+            target_texts = translator.translate(
+                transcribed_opt_sub.texts,
+                src_lang=transcribed_opt_sub.lang,
+                target_lang=target_lang,
+                info=context,
+                compare_path=compare_path,
+            )
 
-            def _open_bot(model):
-                return stack.enter_context(create_chatbot(model, self.fee_limit, self.proxy, self.base_url_config))
-
-            with ExitStack() as stack:
-                chatbot = _open_bot(self.chatbot_model)
-                retry_bot = _open_bot(self.retry_model) if self.retry_model else None
-                translator = LLMTranslator(chatbot=chatbot, retry_chatbot=retry_bot)
-
-                target_texts = translator.translate(
-                    transcribed_opt_sub.texts,
-                    src_lang=transcribed_opt_sub.lang,
-                    target_lang=target_lang,
-                    info=context,
-                    compare_path=compare_path,
-                )
-
-                with self._lock:
-                    self.api_fee += translator.api_fee  # Ensure thread-safe
+            with self._lock:
+                self.api_fee += translator.api_fee  # Ensure thread-safe
 
             translated_sub = deepcopy(transcribed_opt_sub)
             translated_sub.set_texts(target_texts, lang=target_lang)


### PR DESCRIPTION
## Motivation

After PR #113  moved ChatBot creation from `LLMTranslator` to `LRCer._translate()`, each file translation still creates and destroys its own ChatBot (HTTP connection pool). Translating 10 files means 10 TLS handshakes and 10 connection teardowns to the same API endpoint.

This PR lifts ChatBot lifecycle to the `LRCer` instance level using lazy initialization — the same pattern already used for `Transcriber`. ChatBot instances are created on first access and shared across all files processed by the same `LRCer`.

## Changes

- Added `chatbot` and `retry_chatbot` as lazy-initialized properties on `LRCer`, with thread-safe double-checked locking (consistent with the existing `transcriber` property).
- Added `close()` method and context manager support (`__enter__`/`__exit__`) to `LRCer` for explicit resource cleanup.
- Simplified `_translate()`: removed `ExitStack` / `create_chatbot` / `_open_bot` helper, now uses `self.chatbot` and `self.retry_chatbot` directly.
- Updated `README.md`: fixed outdated `LLMTranslator` example to use the new `create_chatbot()` + `chatbot=` API, and documented the new `with LRCer() as lrcer:` usage pattern.

## Benefits

- **Connection reuse**: 10 files = 1 connection pool instead of 10. TLS handshake and connection setup happen once.
- **Simpler `_translate()`**: no more `ExitStack`, `create_chatbot`, or `_open_bot` helper — just `self.chatbot`.
- **Explicit cleanup**: `with LRCer() as lrcer:` guarantees connections are closed when done.
- **Lazy creation**: ChatBot is only created when translation is actually needed. Users who only call `transcribe()` never pay the cost of establishing an LLM connection.