### PR TITLE
fix: harden error recovery in validators, chatbot retry, and atomic_translate

### DIFF
--- a/openlrc/agents.py
+++ b/openlrc/agents.py
@@ -342,7 +342,7 @@ class ContextReviewerAgent(Agent):
         system_tokens = get_text_token_number(self.prompter.system())
         user_tokens = get_text_token_number(self.prompter.user(text_content, title=title, given_glossary=glossary))
         context_window = self.chatbot.model_info.context_window
-        available_output = int(context_window * 0.95) - system_tokens - user_tokens
+        available_output = int(context_window * 0.90) - system_tokens - user_tokens
 
         if available_output >= self.MIN_OUTPUT_TOKENS:
             try:
@@ -479,7 +479,7 @@ class ContextReviewerAgent(Agent):
         system_tokens = get_text_token_number(self.prompter.system())
         user_overhead = get_text_token_number(self.prompter.user("", title=title, given_glossary=glossary))
         context_window = self.chatbot.model_info.context_window
-        max_text_tokens = int(context_window * 0.95) - system_tokens - user_overhead - self.MIN_OUTPUT_TOKENS
+        max_text_tokens = int(context_window * 0.90) - system_tokens - user_overhead - self.MIN_OUTPUT_TOKENS
 
         if max_text_tokens < self.MIN_CHUNK_TEXT_TOKENS:
             logger.warning(
@@ -541,7 +541,7 @@ class ContextReviewerAgent(Agent):
         """
         merge_system_tokens = get_text_token_number(self.prompter.merge_system())
         context_window = self.chatbot.model_info.context_window
-        max_merge_input = int(context_window * 0.95) - merge_system_tokens - self.MIN_OUTPUT_TOKENS
+        max_merge_input = int(context_window * 0.90) - merge_system_tokens - self.MIN_OUTPUT_TOKENS
 
         user_content = self.prompter.merge_user(guidelines, title=title)
         user_tokens = get_text_token_number(user_content)

--- a/openlrc/chatbot.py
+++ b/openlrc/chatbot.py
@@ -104,14 +104,14 @@ class ChatBot:
         """Dynamically compute max_tokens based on input size and model context window.
 
         Prevents context window overflow by capping output tokens to the remaining
-        space after input tokens, with a 5% safety margin for tokenizer estimation error.
+        space after input tokens, with a 10% safety margin for tokenizer estimation error.
         Returns at least 1024 to avoid overly truncated output.
         """
         input_tokens = get_messages_token_number(messages)
         context_window = self.model_info.context_window
         model_max = self.model_info.max_tokens
 
-        available = int(context_window * 0.95) - input_tokens
+        available = int(context_window * 0.90) - input_tokens
         computed = min(model_max, max(available, 1024))
 
         if computed < model_max:
@@ -334,6 +334,7 @@ class GPTBot(ChatBot):
         effective_top_p = top_p if top_p is not None else self.top_p
 
         response = None
+        validated = False
         for i in range(self.retry):
             try:
                 response = self.client.chat.completions.create(
@@ -355,6 +356,7 @@ class GPTBot(ChatBot):
                     logger.warning(f"Invalid response format. Retry num: {i + 1}.")
                     continue
 
+                validated = True
                 break
             except openai.AuthenticationError as e:
                 # Authentication errors are deterministic and should not be retried.
@@ -382,6 +384,9 @@ class GPTBot(ChatBot):
 
         if not response:
             raise ChatBotException("Failed to create a chat.")
+
+        if not validated:
+            logger.warning("Response format validation failed after all retries, returning best-effort response.")
 
         return response
 
@@ -462,10 +467,12 @@ class ClaudeBot(ChatBot):
 
         # Move "system" role into the parameters
         system_msg = NOT_GIVEN
+        messages = list(messages)  # Shallow copy to avoid mutating the caller's list.
         if messages[0]["role"] == "system":
             system_msg = messages.pop(0)["content"]
 
         response = None
+        validated = False
         for i in range(self.retry):
             try:
                 response = self.client.messages.create(
@@ -488,6 +495,7 @@ class ClaudeBot(ChatBot):
                     logger.warning(f"Invalid response format. Retry num: {i + 1}.")
                     continue
 
+                validated = True
                 break
             except anthropic.AuthenticationError as e:
                 # Authentication errors are deterministic and should not be retried.
@@ -514,6 +522,9 @@ class ClaudeBot(ChatBot):
 
         if not response:
             raise ChatBotException("Failed to create a chat.")
+
+        if not validated:
+            logger.warning("Response format validation failed after all retries, returning best-effort response.")
 
         return response
 
@@ -633,6 +644,7 @@ class GeminiBot(ChatBot):
         )
 
         response = None
+        validated = False
         for i in range(self.retry):
             # send_message_async is buggy, so we use send_message instead as a workaround
             response = self.client.models.generate_content(model=self.model_name, contents=user_msg, config=config)
@@ -652,10 +664,14 @@ class GeminiBot(ChatBot):
                 logger.warning(f"Failed to get a complete response. Retry num: {i + 1}.")
                 continue
 
+            validated = True
             break
 
         if not response:
             raise ChatBotException("Failed to create a chat.")
+
+        if not validated:
+            logger.warning("Response format validation failed after all retries, returning best-effort response.")
 
         return response
 

--- a/openlrc/translate.py
+++ b/openlrc/translate.py
@@ -364,7 +364,10 @@ class LLMTranslator(Translator):
         self.api_fee += sum(chatbot.api_fees[-(len(texts)) :])
         translated = list(map(chatbot.get_content, responses))
 
-        assert len(translated) == len(texts), f"Atomic translation failed: {len(translated)} vs {len(texts)}"
+        if len(translated) != len(texts):
+            raise ChatBotException(
+                f"Atomic translation failed: expected {len(texts)} translations, got {len(translated)}"
+            )
 
         return translated
 

--- a/openlrc/validators.py
+++ b/openlrc/validators.py
@@ -72,6 +72,10 @@ class ChunkedTranslateValidator(BaseValidator):
         return True
 
     def validate(self, user_input, generated_content):
+        if not generated_content:
+            logger.warning("Empty or None response content.")
+            return False
+
         summary = re.search(r"<summary>(.*)</summary>", generated_content)
         scene = re.search(r"<scene>(.*)</scene>", generated_content)
 
@@ -111,6 +115,10 @@ class AtomicTranslateValidator(BaseValidator):
         self.target_lang = target_lang
 
     def validate(self, user_input, generated_content):
+        if not generated_content:
+            logger.warning("Empty or None response content.")
+            return False
+
         detected_lang = self.lan_detector.detect_language_of(generated_content)
         if not detected_lang:
             return True
@@ -126,6 +134,10 @@ class AtomicTranslateValidator(BaseValidator):
 
 class ProofreaderValidator(BaseValidator):
     def validate(self, user_input, generated_content):
+        if not generated_content:
+            logger.warning("Empty or None response content.")
+            return False
+
         original = re.findall(ORIGINAL_PREFIX + r"\n(.*?)\n" + TRANSLATION_PREFIX, user_input, re.DOTALL)
         if not original:
             logger.error("Fail to extract original text.")
@@ -161,6 +173,10 @@ class ContextReviewerValidateValidator(BaseValidator):
         Returns:
             bool: True if validation passes, False otherwise.
         """
+        if not generated_content:
+            logger.warning("Empty or None response content.")
+            return False
+
         if re.search(r"\b(?:true|false)\b", generated_content, re.IGNORECASE):
             return True
         else:


### PR DESCRIPTION
## Fix

This PR fixes four error recovery bugs and increases the tokenizer safety margin.

### 1. Validators crash on None response content

When the LLM API returns an empty response, `get_content()` returns `None`. All four validators (`ChunkedTranslateValidator`, `AtomicTranslateValidator`, `ProofreaderValidator`, `ContextReviewerValidateValidator`) pass this directly to `re.search()` or `detect_language_of()`, which raises `TypeError: expected string or bytes-like object`. This was observed on CI.

Added `if not generated_content: return False` guard to all four validators.

### 2. ClaudeBot mutates caller's message list

`ClaudeBot._create_chat()` calls `messages.pop(0)` to extract the system message, which modifies the caller's list in place. If the retry loop re-enters or if the same message list is reused, the system message is already gone. `GeminiBot` already avoids this with `deepcopy(messages)`.

Added `messages = list(messages)` shallow copy before the `pop`.

### 3. `_create_chat` silently returns unvalidated response

When `output_checker` fails on every retry attempt, the retry loop exits normally. Since the API call itself succeeded, `response` is not `None`, so the `if not response` guard does not trigger. The method returns a response that never passed format validation, and the caller has no way to know.

Added a `validated` flag that is set to `True` only when `output_checker` passes. After the loop, if `not validated`, a warning is logged. This makes the failure visible in logs while preserving the existing best-effort behavior (returning the last response rather than raising).

### 4. `atomic_translate` uses `assert` for error handling

`assert` is stripped in `python -O` mode. As the last fallback in the translation pipeline, `atomic_translate` should always report failures reliably.

Replaced `assert len(translated) == len(texts)` with `if ... raise ChatBotException(...)`.

### 5. Tokenizer safety margin increased from 5% to 10%

`_compute_max_tokens()` and the three token budget calculations in `ContextReviewerAgent` use a safety margin to account for the difference between tiktoken's token estimates and the actual model's tokenizer. CI logs showed divergences of 3-3.5% on non-GPT models (Gemini via OpenRouter), which is close enough to 5% to cause `LengthExceedException` on large chunks. Increased to 10% to provide sufficient headroom.