### PR TITLE
refactor: reduce translation log noise, add OPENLRC_LOG_LEVEL env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       OPENLRC_TEST_LIVE_API: "1"
+      OPENLRC_LOG_LEVEL: "DEBUG"
     steps:
       - uses: actions/checkout@v4
 

--- a/openlrc/agents.py
+++ b/openlrc/agents.py
@@ -445,7 +445,7 @@ class ContextReviewerAgent(Agent):
                     f"Finally failed to validate the context: {context}, you may check the context manually."
                 )
                 context = max(context_pool, key=len) if context_pool else ""
-                logger.info(f"Now using the longest context: {context}")
+                logger.debug(f"Now using the longest context: {context}")
 
         if not context:
             context = ""

--- a/openlrc/chatbot.py
+++ b/openlrc/chatbot.py
@@ -116,7 +116,7 @@ class ChatBot:
         computed = min(model_max, max(available, 1024))
 
         if computed < model_max:
-            logger.info(
+            logger.debug(
                 f"Dynamic max_tokens: {computed} "
                 f"(input={input_tokens}, context_window={context_window}, model_max={model_max})"
             )
@@ -183,13 +183,13 @@ class ChatBot:
 
         # Calculate the total sending token number and approximated billing fee.
         token_numbers = [get_messages_token_number(message) for message in normalised]
-        logger.info(
+        logger.debug(
             f"Max token num: {max(token_numbers):.0f}, Avg token num: {sum(token_numbers) / len(token_numbers):.0f}"
         )
 
         # if the approximated billing fee exceeds the limit, raise an exception.
         approximated_fee = sum([self.estimate_fee(messages) for messages in normalised])
-        logger.info(f"Approximated billing fee: {approximated_fee:.4f} USD")
+        logger.debug(f"Approximated billing fee: {approximated_fee:.4f} USD")
         self.api_fees += [0]  # Actual fee for this translation call.
         if approximated_fee > self.fee_limit:
             raise ChatBotException(f"Approximated billing fee {approximated_fee} exceeds the limit: {self.fee_limit}$.")
@@ -212,8 +212,8 @@ class ChatBot:
             logger.error(f"Failed to message with GPT. Error: {e}")
             raise
         finally:
-            logger.info(f"Translation fee for this call: {self.api_fees[-1]:.4f} USD")
-            logger.info(f"Total bot translation fee: {sum(self.api_fees):.4f} USD")
+            logger.debug(f"Translation fee for this call: {self.api_fees[-1]:.4f} USD")
+            logger.debug(f"Total bot translation fee: {sum(self.api_fees):.4f} USD")
 
         return results
 

--- a/openlrc/logger.py
+++ b/openlrc/logger.py
@@ -2,6 +2,7 @@
 #  All rights reserved.
 
 import logging
+import os
 
 from colorlog import ColoredFormatter
 
@@ -22,4 +23,4 @@ logger.handlers.clear()  # Clear existing handlers
 logger.addHandler(handler)
 logger.propagate = False
 
-logger.setLevel("INFO")
+logger.setLevel(os.environ.get("OPENLRC_LOG_LEVEL", "INFO").upper())

--- a/openlrc/translate.py
+++ b/openlrc/translate.py
@@ -213,7 +213,7 @@ class LLMTranslator(Translator):
             guideline = context_reviewer.build_context(
                 texts, title=info.title or "", glossary=info.glossary, forced_glossary=info.forced_glossary
             )
-            logger.info(f"Translation Guideline:\n{guideline}")
+            logger.debug(f"Translation Guideline:\n{guideline}")
 
         context = TranslationContext(guideline=guideline, previous_summaries=summaries)
         for i, chunk in list(enumerate(chunks, start=1))[start_chunk:]:
@@ -236,14 +236,16 @@ class LLMTranslator(Translator):
             translations.extend(translated)
             summaries.append(context.summary or "")
             logger.info(f"Translated {info.title}: {i}/{len(chunks)}")
-            logger.info(f"Summary: {context.summary}")
-            logger.info(f"Scene: {context.scene}")
+            logger.debug(f"Summary: {context.summary}")
+            logger.debug(f"Scene: {context.scene}")
 
             compare_list.extend(self._generate_compare_list(chunk, translated, i, atomic, context))
             self._save_intermediate_results(compare_path, compare_list, summaries, context.scene or "", guideline)
             context.previous_summaries = summaries
 
         self.api_fee += translator_agent.cost + (retry_agent.cost if retry_agent else 0)
+
+        logger.info(f"Translation complete for {info.title}. Fee: {self.api_fee:.4f} USD")
 
         return translations
 


### PR DESCRIPTION

## Summary

Reduce log noise during translation by demoting verbose per-call diagnostics from `info` to `debug`, and add `OPENLRC_LOG_LEVEL` environment variable for configurable log levels.

## Problem

Translating a file with 2 chunks previously produced 25+ info-level log lines, most of which were per-API-call diagnostics (token counts, estimated fees, actual fees, cumulative fees) repeated for every `message()` call. The full translation guideline (potentially hundreds of lines) and per-chunk summary/scene were also logged at info level, drowning out the actual progress information.

## Changes

**`openlrc/logger.py`** — Log level is now configurable via `OPENLRC_LOG_LEVEL` environment variable, defaulting to `INFO`.

**`openlrc/chatbot.py`** — Demoted to `debug`:
- `Max token num` / `Avg token num` (per `message()` call)
- `Approximated billing fee` (per `message()` call)
- `Translation fee for this call` (per `message()` call)
- `Total bot translation fee` (per `message()` call)
- `Dynamic max_tokens` (per `_create_chat()` call)

**`openlrc/translate.py`** — Demoted to `debug`:
- `Translation Guideline:\n{...}` (full guideline content)
- `Summary: ...` (per chunk)
- `Scene: ...` (per chunk)

Added at `info` level:
- `Translation complete for {title}. Fee: X.XXXX USD` (once per file, at the end)

**`openlrc/agents.py`** — Demoted to `debug`:
- `Now using the longest context: ...` (full context content on validation failure)

**`.github/workflows/ci.yml`** — Added `OPENLRC_LOG_LEVEL: "DEBUG"` so CI live API tests retain full diagnostic output for troubleshooting.

## Before / After

Info-level output for a 2-chunk translation:

**Before (25+ lines):**
```
[INFO] Max token num: 825, Avg token num: 825
[INFO] Approximated billing fee: 0.0008 USD
[INFO] Translation fee for this call: 0.0008 USD
[INFO] Total bot translation fee: 0.0008 USD
[INFO] Translating test_audio: 2 chunks, 60 lines in total.
[INFO] Building translation guideline.
[INFO] Max token num: 1067, Avg token num: 1067
[INFO] Approximated billing fee: 0.0012 USD
[INFO] Dynamic max_tokens: 6950 (input=832, ...)
[INFO] Translation fee for this call: 0.0012 USD
[INFO] Total bot translation fee: 0.0020 USD
[INFO] Translation Guideline:
### Glossary:
... (dozens of lines)
[INFO] Translated test_audio: 1/2
[INFO] Summary: A brief conversation...
[INFO] Scene: Two people greeting...
... (repeated for each chunk and API call)
```

**After (5 lines):**
```
[INFO] Translating test_audio: 2 chunks, 60 lines in total.
[INFO] Building translation guideline.
[INFO] Translated test_audio: 1/2
[INFO] Translated test_audio: 2/2
[INFO] Translation complete for test_audio. Fee: 0.0050 USD
```

All demoted logs remain available at `debug` level. Set `OPENLRC_LOG_LEVEL=DEBUG` to see them.