### PR TITLE
refactor: extract hardcoded filename suffixes into constants in defau…

### DIFF
--- a/openlrc/defaults.py
+++ b/openlrc/defaults.py
@@ -42,6 +42,25 @@ default_vad_options = {
 
 default_preprocess_options = {"atten_lim_db": 15}
 
+# File name suffixes used throughout the pipeline.
+# The processing chain produces files like:
+#   audio.wav → preprocessed/audio_preprocessed.wav
+#     → audio_preprocessed_transcribed.json
+#       → audio_preprocessed_transcribed_optimized.json
+#         → audio_preprocessed_transcribed_optimized_translated.json
+PREPROCESSED_SUFFIX = "_preprocessed"
+TRANSCRIBED_SUFFIX = "_transcribed"
+OPTIMIZED_SUFFIX = "_optimized"
+TRANSLATED_SUFFIX = "_translated"
+COMPARE_SUFFIX = "_compare"
+NONTRANS_SUFFIX = "_nontrans"
+BILINGUAL_SUFFIX = "_bilingual"
+NOISE_SUPPRESSED_SUFFIX = "_ns"
+LOUDNORM_SUFFIX = "_ln"
+
+# Directory name for preprocessed audio files.
+PREPROCESSED_DIR = "preprocessed"
+
 # Currently bottleneck-ed by Spacy
 supported_languages = {
     "ca",

--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -19,7 +19,17 @@ if TYPE_CHECKING:
     from faster_whisper.transcribe import Segment
 
 from openlrc.config import TranscriptionConfig, TranslationConfig
-from openlrc.defaults import default_asr_options, default_preprocess_options, default_vad_options
+from openlrc.defaults import (
+    COMPARE_SUFFIX,
+    NONTRANS_SUFFIX,
+    PREPROCESSED_DIR,
+    PREPROCESSED_SUFFIX,
+    TRANSCRIBED_SUFFIX,
+    TRANSLATED_SUFFIX,
+    default_asr_options,
+    default_preprocess_options,
+    default_vad_options,
+)
 from openlrc.logger import logger
 from openlrc.opt import SubtitleOptimizer
 from openlrc.subtitle import BilingualSubtitle, Subtitle
@@ -264,7 +274,7 @@ class LRCer:
         Returns:
             Path: Path to the transcribed JSON file.
         """
-        transcribed_path = extend_filename(audio_path, "_transcribed").with_suffix(".json")
+        transcribed_path = extend_filename(audio_path, TRANSCRIBED_SUFFIX).with_suffix(".json")
         if not transcribed_path.exists():
             with Timer("Transcription process"):
                 logger.info(
@@ -347,7 +357,7 @@ class LRCer:
     @staticmethod
     def _get_base_name(transcribed_path: Path) -> str:
         """Extract the original audio base name from a transcribed JSON path."""
-        return transcribed_path.stem.replace("_preprocessed_transcribed", "")
+        return transcribed_path.stem.replace(f"{PREPROCESSED_SUFFIX}{TRANSCRIBED_SUFFIX}", "")
 
     def _is_video_transcription(self, transcribed_path: Path, base_name: str) -> bool:
         """
@@ -380,7 +390,7 @@ class LRCer:
         Returns:
             Subtitle: The final subtitle (translated or copied), or None on error.
         """
-        translated_path = extend_filename(transcribed_opt_sub.filename, "_translated")
+        translated_path = extend_filename(transcribed_opt_sub.filename, TRANSLATED_SUFFIX)
         final_json_path = translated_path.with_name(f"{base_name}.json")
 
         if final_json_path.exists():
@@ -433,7 +443,9 @@ class LRCer:
         optimizer = SubtitleOptimizer(non_translated_subtitle)
         optimizer.extend_time()
         non_translated_path = getattr(non_translated_subtitle, f"to_{subtitle_format}")()
-        shutil.move(non_translated_path, non_translated_path.parent.parent / f"{base_name}_nontrans.{subtitle_format}")
+        shutil.move(
+            non_translated_path, non_translated_path.parent.parent / f"{base_name}{NONTRANS_SUFFIX}.{subtitle_format}"
+        )
 
     def _process_transcribed_file(
         self, transcribed_path: Path, target_lang: str | None, skip_trans: bool = False, bilingual_sub: bool = False
@@ -574,7 +586,7 @@ class LRCer:
         )
 
         json_filename = Path(translated_path.parent / (audio_name + ".json"))
-        compare_path = Path(translated_path.parent, f"{audio_name}_compare.json")
+        compare_path = Path(translated_path.parent, f"{audio_name}{COMPARE_SUFFIX}.json")
         if not translated_path.exists():
             translator = LLMTranslator(chatbot=self.chatbot, retry_chatbot=self.retry_chatbot)
 
@@ -740,7 +752,7 @@ class LRCer:
         """
         temp_folders = {path.parent for path in paths}
         for folder in temp_folders:
-            assert folder.name == "preprocessed", f"Not a temporary folder: {folder}"
+            assert folder.name == PREPROCESSED_DIR, f"Not a temporary folder: {folder}"
 
             shutil.rmtree(folder)
             logger.debug(f"Removed {folder}")

--- a/openlrc/opt.py
+++ b/openlrc/opt.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import zhconv
 
+from openlrc.defaults import OPTIMIZED_SUFFIX
 from openlrc.logger import logger
 from openlrc.subtitle import BilingualSubtitle, Subtitle
 from openlrc.utils import extend_filename, format_timestamp
@@ -272,7 +273,7 @@ class SubtitleOptimizer:
         """
         Save the optimized subtitle to a file.
         """
-        optimized_name = extend_filename(self.filename, "_optimized") if not output_name else output_name
+        optimized_name = extend_filename(self.filename, OPTIMIZED_SUFFIX) if not output_name else output_name
         self.subtitle.save(optimized_name, update_name=update_name)
         logger.info(f"Optimized json file saved to {optimized_name}")
 

--- a/openlrc/preprocess.py
+++ b/openlrc/preprocess.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ffmpeg_normalize import FFmpegNormalize
 from tqdm import tqdm
 
-from openlrc.defaults import default_preprocess_options
+from openlrc.defaults import LOUDNORM_SUFFIX, NOISE_SUPPRESSED_SUFFIX, PREPROCESSED_DIR, default_preprocess_options
 from openlrc.logger import logger
 from openlrc.utils import get_preprocessed_path, release_memory
 
@@ -40,7 +40,7 @@ class Preprocessor:
     def __init__(
         self,
         audio_paths: str | Path | list[str] | list[Path],
-        output_folder: str = "preprocessed",
+        output_folder: str = PREPROCESSED_DIR,
         options: dict | None = None,
     ):
         if options is None:
@@ -66,8 +66,7 @@ class Preprocessor:
             from df.enhance import enhance, init_df, load_audio, save_audio
         except ImportError:
             raise ImportError(
-                "Noise suppression requires torch and deepfilternet. "
-                "Install them with: pip install 'openlrc[full]'"
+                "Noise suppression requires torch and deepfilternet. Install them with: pip install 'openlrc[full]'"
             )
 
         if "atten_lim_db" in self.options:
@@ -79,7 +78,7 @@ class Preprocessor:
         ns_audio_paths = []
         for audio_path, output_path in zip(audio_paths, self.output_paths):
             audio_name = audio_path.stem
-            ns_path = output_path / f"{audio_name}_ns.wav"
+            ns_path = output_path / f"{audio_name}{NOISE_SUPPRESSED_SUFFIX}.wav"
 
             if not ns_path.exists():
                 audio, info = load_audio(audio_path, sr=df_state.sr())
@@ -117,7 +116,7 @@ class Preprocessor:
         args = []
         ln_audio_paths = []
         for audio_path, output_path in zip(audio_paths, self.output_paths):
-            ln_path = output_path / f"{audio_path.stem}_ln.wav"
+            ln_path = output_path / f"{audio_path.stem}{LOUDNORM_SUFFIX}.wav"
             args.append((audio_path, ln_path))
             ln_audio_paths.append(ln_path)
 

--- a/openlrc/subtitle.py
+++ b/openlrc/subtitle.py
@@ -8,6 +8,13 @@ from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 
+from openlrc.defaults import (
+    BILINGUAL_SUFFIX,
+    OPTIMIZED_SUFFIX,
+    PREPROCESSED_SUFFIX,
+    TRANSCRIBED_SUFFIX,
+    TRANSLATED_SUFFIX,
+)
 from openlrc.logger import logger
 from openlrc.utils import detect_lang, format_timestamp, parse_timestamp
 
@@ -285,8 +292,9 @@ class BilingualSubtitle:
 
     @classmethod
     def from_preprocessed(cls, preprocessed_folder, audio_name):
-        src_file = preprocessed_folder / f"{audio_name}_preprocessed_transcribed_optimized.json"
-        target_file = preprocessed_folder / f"{audio_name}_preprocessed_transcribed_optimized_translated.json"
+        _opt = f"{audio_name}{PREPROCESSED_SUFFIX}{TRANSCRIBED_SUFFIX}{OPTIMIZED_SUFFIX}"
+        src_file = preprocessed_folder / f"{_opt}.json"
+        target_file = preprocessed_folder / f"{_opt}{TRANSLATED_SUFFIX}.json"
 
         if not src_file.exists() or not target_file.exists():
             raise ValueError(f"Preprocessed file not found for {audio_name}")
@@ -294,7 +302,7 @@ class BilingualSubtitle:
         src_sub = Subtitle.from_json(src_file)
         target_sub = Subtitle.from_json(target_file)
 
-        bilingual_sub_name = preprocessed_folder / f"{audio_name}_bilingual.json"
+        bilingual_sub_name = preprocessed_folder / f"{audio_name}{BILINGUAL_SUFFIX}.json"
 
         return cls(src_sub, target_sub, filename=bilingual_sub_name)
 

--- a/openlrc/utils.py
+++ b/openlrc/utils.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from spacy.language import Language as SpacyLanguage
 
-from openlrc.defaults import supported_languages_lingua
+from openlrc.defaults import PREPROCESSED_DIR, PREPROCESSED_SUFFIX, supported_languages_lingua
 from openlrc.logger import logger
 
 
@@ -71,7 +71,7 @@ def get_preprocessed_path(audio_path: str | Path) -> Path:
         PosixPath('/data/preprocessed/audio_preprocessed.wav')
     """
     audio_path = Path(audio_path)
-    return audio_path.parent / "preprocessed" / f"{audio_path.stem}_preprocessed.wav"
+    return audio_path.parent / PREPROCESSED_DIR / f"{audio_path.stem}{PREPROCESSED_SUFFIX}.wav"
 
 
 def get_file_type(path: Path) -> str:


### PR DESCRIPTION
## Summary

Extract all hardcoded filename suffixes and directory names into named constants in `defaults.py`.

## Problem

The processing pipeline produces a chain of intermediate files:

```
audio.wav
  → preprocessed/audio_preprocessed.wav
    → audio_preprocessed_transcribed.json
      → audio_preprocessed_transcribed_optimized.json
        → audio_preprocessed_transcribed_optimized_translated.json
```

Each suffix (`_preprocessed`, `_transcribed`, `_optimized`, `_translated`, etc.) was hardcoded as a bare string literal at every usage site across 5 files. Some suffixes were concatenated inline (e.g. `"_preprocessed_transcribed_optimized"` in `subtitle.py`), making it easy to introduce inconsistencies if any suffix is renamed.

## Changes

Added 10 constants to `openlrc/defaults.py`:

```python
PREPROCESSED_SUFFIX = "_preprocessed"
TRANSCRIBED_SUFFIX = "_transcribed"
OPTIMIZED_SUFFIX = "_optimized"
TRANSLATED_SUFFIX = "_translated"
COMPARE_SUFFIX = "_compare"
NONTRANS_SUFFIX = "_nontrans"
BILINGUAL_SUFFIX = "_bilingual"
NOISE_SUPPRESSED_SUFFIX = "_ns"
LOUDNORM_SUFFIX = "_ln"
PREPROCESSED_DIR = "preprocessed"
```

Replaced all hardcoded occurrences across 5 files:

| File | Replacements |
|---|---|
| `utils.py` | `get_preprocessed_path()`: directory name and suffix |
| `openlrc.py` | `_transcribe_single()`, `_get_base_name()`, `_build_final_subtitle()`, `_handle_bilingual_subtitles()`, `_translate()`, `clear_temp_files()` |
| `opt.py` | `save()` |
| `subtitle.py` | `BilingualSubtitle.from_preprocessed()` |
| `preprocess.py` | `Preprocessor.__init__()`, noise suppression path, loudness normalization path |

No logic changes. Pure rename refactoring.