### PR TITLE
fix: replace assert statements with proper exceptions across codebase

### DIFF
--- a/openlrc/chatbot.py
+++ b/openlrc/chatbot.py
@@ -56,7 +56,8 @@ def _register_chatbot(cls):
 def route_chatbot(model: str) -> tuple[type, str]:
     if ":" in model:
         match = re.match(r"(.+):(.+)", model)
-        assert match is not None, f"Invalid model format: {model!r}"
+        if match is None:
+            raise ValueError(f"Invalid model format: {model!r}")
         chatbot_type, chatbot_model = match.groups()
         chatbot_type, chatbot_model = chatbot_type.strip().lower(), chatbot_model.strip()
 
@@ -172,7 +173,8 @@ class ChatBot:
             temperature: Sampling temperature for this call. Falls back to the instance default if None.
             top_p: Top-p sampling for this call. Falls back to the instance default if None.
         """
-        assert messages_list, "Empty message list."
+        if not messages_list:
+            raise ValueError("Empty message list.")
 
         # Normalise to list[list[dict]] so downstream code has a single type.
         normalised: list[list[dict]]
@@ -351,7 +353,12 @@ class GPTBot(ChatBot):
                 )
                 self.update_fee(response)
                 if response.choices[0].finish_reason == "length":
-                    raise LengthExceedException(response)
+                    usage = response.usage
+                    raise LengthExceedException(
+                        prompt_tokens=usage.prompt_tokens if usage else -1,
+                        completion_tokens=usage.completion_tokens if usage else -1,
+                        total_tokens=usage.total_tokens if usage else -1,
+                    )
 
                 response_text = remove_stop(self.get_content(response), stop_sequences)
 
@@ -493,7 +500,12 @@ class ClaudeBot(ChatBot):
                 self.update_fee(response)
 
                 if response.stop_reason == "max_tokens":
-                    raise LengthExceedException(response)
+                    usage = response.usage
+                    raise LengthExceedException(
+                        prompt_tokens=usage.input_tokens if usage else -1,
+                        completion_tokens=usage.output_tokens if usage else -1,
+                        total_tokens=(usage.input_tokens + usage.output_tokens) if usage else -1,
+                    )
 
                 response_text = remove_stop(self.get_content(response), stop_sequences)
 

--- a/openlrc/exceptions.py
+++ b/openlrc/exceptions.py
@@ -1,9 +1,6 @@
 #  Copyright (C) 2024. Hao Zheng
 #  All rights reserved.
 
-from anthropic.types import Message
-from openai.types.chat import ChatCompletion
-
 
 class SameLanguageException(Exception):
     """
@@ -31,19 +28,7 @@ class LengthExceedException(ChatBotException):
     Raised when the length of generated response exceeds the limit.
     """
 
-    def __init__(self, response: ChatCompletion | Message):
-        if isinstance(response, ChatCompletion):
-            assert response.usage is not None, "ChatCompletion.usage is None"
-            prompt_tokens = response.usage.prompt_tokens
-            completion_tokens = response.usage.completion_tokens
-            total_tokens = response.usage.total_tokens
-        elif isinstance(response, Message):
-            prompt_tokens = response.usage.input_tokens
-            completion_tokens = response.usage.output_tokens
-            total_tokens = prompt_tokens + completion_tokens
-        else:
-            raise ValueError(f"Invalid response type: {type(response)}")
-
+    def __init__(self, prompt_tokens: int = -1, completion_tokens: int = -1, total_tokens: int = -1):
         super().__init__(
             f"Failed to get completion. Exceed max token length. "
             f"Prompt tokens: {prompt_tokens}, "

--- a/openlrc/openlrc.py
+++ b/openlrc/openlrc.py
@@ -753,7 +753,8 @@ class LRCer:
         """
         temp_folders = {path.parent for path in paths}
         for folder in temp_folders:
-            assert folder.name == PREPROCESSED_DIR, f"Not a temporary folder: {folder}"
+            if folder.name != PREPROCESSED_DIR:
+                raise ValueError(f"Not a temporary folder: {folder}")
 
             shutil.rmtree(folder)
             logger.debug(f"Removed {folder}")

--- a/openlrc/opt.py
+++ b/openlrc/opt.py
@@ -83,7 +83,8 @@ class SubtitleOptimizer:
 
                 # Merge to previous element if closer to pre-element and gap > 3s
                 previous_gap = current_segment.start - optimized_segments[-1].start
-                assert current_segment.end is not None, "Segment end time must be set for merging"
+                if current_segment.end is None:
+                    raise ValueError("Segment end time must be set for merging")
                 next_gap = element.start - current_segment.end
                 if previous_gap <= next_gap and previous_gap <= 3:
                     previous_element = optimized_segments.pop()

--- a/openlrc/preprocess.py
+++ b/openlrc/preprocess.py
@@ -95,9 +95,10 @@ class Preprocessor:
 
                 enhanced = torch.cat(enhanced_chunks, dim=1)
 
-                assert enhanced.shape == audio.shape, (
-                    f"Enhanced audio shape does not match original audio shape: {enhanced.shape} != {audio.shape}"
-                )
+                if enhanced.shape != audio.shape:
+                    raise ValueError(
+                        f"Enhanced audio shape does not match original audio shape: {enhanced.shape} != {audio.shape}"
+                    )
 
                 save_audio(ns_path, enhanced, sr=df_state.sr())
 

--- a/openlrc/subtitle.py
+++ b/openlrc/subtitle.py
@@ -79,7 +79,8 @@ class Subtitle:
 
     def set_texts(self, texts, lang=None):
         # Check length
-        assert len(texts) == len(self.segments)
+        if len(texts) != len(self.segments):
+            raise ValueError(f"Text count ({len(texts)}) does not match segment count ({len(self.segments)})")
 
         for i, text in enumerate(texts):
             self.segments[i].text = text
@@ -122,7 +123,8 @@ class Subtitle:
             for i, segment in enumerate(self.segments):
                 print(f"[{fmt(segment.start)}] {segment.text}", file=f, flush=True)
                 if i == len(self.segments) - 1 or segment.end != self.segments[i + 1].start:
-                    assert segment.end is not None, "Segment end time is required for LRC output"
+                    if segment.end is None:
+                        raise ValueError("Segment end time is required for LRC output")
                     print(f"[{fmt(segment.end)}]", file=f, flush=True)
 
         logger.info(f"File saved to {lrc_path}")
@@ -134,7 +136,8 @@ class Subtitle:
         fmt = partial(format_timestamp, fmt="srt")
         with open(srt_path, "w", encoding="utf-8") as f:
             for i, segment in enumerate(self.segments, start=1):
-                assert segment.end is not None, "Segment end time is required for SRT output"
+                if segment.end is None:
+                    raise ValueError("Segment end time is required for SRT output")
                 print(f"{i}\n{fmt(segment.start)} --> {fmt(segment.end)}\n{segment.text}\n", file=f, flush=True)
 
         logger.info(f"File saved to {srt_path}")
@@ -157,13 +160,15 @@ class Subtitle:
         for i, line in enumerate(lines):
             # get time stamp
             match = re.search(r"\[(\d+:\d+(?:\.\d+)?)](.*)", line)
-            assert match is not None, f"Invalid LRC line: {line!r}"
+            if match is None:
+                raise ValueError(f"Invalid LRC line: {line!r}")
             start_str, text = match.group(1, 2)
             start = parse_timestamp(start_str, fmt="lrc")
 
             if i != len(lines) - 1:
                 next_match = re.search(r"\[(\d+:\d+(?:\.\d+)?)]", lines[i + 1])
-                assert next_match is not None, f"Invalid LRC line: {lines[i + 1]!r}"
+                if next_match is None:
+                    raise ValueError(f"Invalid LRC line: {lines[i + 1]!r}")
                 end_str = next_match.group(1)
                 end = parse_timestamp(end_str, fmt="lrc")
             else:
@@ -205,7 +210,8 @@ class Subtitle:
             line = lines[i]
             if line.strip().isdigit():
                 time_match = re.search(r"(\d+:\d+:\d+,\d+) --> (\d+:\d+:\d+,\d+)", lines[i + 1])
-                assert time_match is not None, f"Invalid SRT timing line: {lines[i + 1]!r}"
+                if time_match is None:
+                    raise ValueError(f"Invalid SRT timing line: {lines[i + 1]!r}")
                 start_str, end_str = time_match.group(1, 2)
                 start = parse_timestamp(start_str, fmt="srt")
                 end = parse_timestamp(end_str, fmt="srt")
@@ -336,7 +342,8 @@ class BilingualSubtitle:
                     flush=True,
                 )
                 if i == len(self.segments) - 1 or segment.end != self.segments[i + 1].start:
-                    assert segment.end is not None, "Segment end time is required for LRC output"
+                    if segment.end is None:
+                        raise ValueError("Segment end time is required for LRC output")
                     print(f"[{fmt(segment.end)}]", file=f, flush=True)
 
         logger.info(f"File saved to {lrc_path}")
@@ -348,7 +355,8 @@ class BilingualSubtitle:
         fmt = partial(format_timestamp, fmt="srt")
         with open(srt_path, "w", encoding="utf-8") as f:
             for i, segment in enumerate(self.segments, start=1):
-                assert segment.end is not None, "Segment end time is required for SRT output"
+                if segment.end is None:
+                    raise ValueError("Segment end time is required for SRT output")
                 print(
                     f"{i}\n"
                     f"{fmt(segment.start)} --> {fmt(segment.end)}\n"

--- a/openlrc/transcribe.py
+++ b/openlrc/transcribe.py
@@ -201,7 +201,8 @@ class Transcriber:
             Returns:
                 list: List of split segments.
             """
-            assert seg_entry.words is not None, "Segment must have word-level timestamps for splitting"
+            if seg_entry.words is None:
+                raise ValueError("Segment must have word-level timestamps for splitting")
             text = seg_entry.text
             doc = nlp(text)
 
@@ -265,7 +266,8 @@ class Transcriber:
         id_cnt = 0
         sentences = []  # [{'text': , 'start': , 'end': , 'words': [{word: , start: , end: , score: }, ...]}, ...]
         for segment in segments:
-            assert segment.words is not None, "Segment must have word-level timestamps"
+            if segment.words is None:
+                raise ValueError("Segment must have word-level timestamps")
             # Use pysbd to split the segment text into potential sentences
             splits = [s for s in segmenter.segment(segment.text) if s]  # Also filter out empty splits
             word_start = 0
@@ -317,7 +319,8 @@ class Transcriber:
                         list: List of segments after recursive splitting.
                     """
                     # Check if the segment needs splitting
-                    assert entry.words is not None, "Segment must have word-level timestamps"
+                    if entry.words is None:
+                        raise ValueError("Segment must have word-level timestamps")
                     char_limit = 45 if lang in self.continuous_scripted else 90
                     if len(entry.text) < char_limit or len(entry.words) == 1:
                         if entry.end - entry.start > 10:  # Split if duration > 10s

--- a/openlrc/utils.py
+++ b/openlrc/utils.py
@@ -169,12 +169,14 @@ class Timer:
 
     @property
     def _elapsed(self) -> float:
-        assert self._start is not None and self._stop is not None, "Timer not started/stopped"
+        if self._start is None or self._stop is None:
+            raise RuntimeError("Timer not started/stopped")
         return self._stop - self._start
 
     @property
     def duration(self) -> float:
-        assert self._start is not None, "Timer not started"
+        if self._start is None:
+            raise RuntimeError("Timer not started")
         return time.perf_counter() - self._start
 
     def __enter__(self):

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -72,7 +72,7 @@ class TestSubtitle(unittest.TestCase):
 
     def test_set_texts_edge_case(self):
         subtitle = self.subtitle
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             subtitle.set_texts(["Hello"])
 
     def test_set_texts_edge_case_2(self):


### PR DESCRIPTION
## Summary

Replace all `assert` statements with proper exceptions and simplify `LengthExceedException`.

## Problem

The codebase used `assert` for runtime validation in 18 places across 8 files. `assert` statements are stripped in `python -O` mode, silently disabling all these checks. Several of these guard critical invariants (e.g., segment end times, text/segment count matching, message list validation) that should always be enforced.

Additionally, `exceptions.py` imported `anthropic.types.Message` and `openai.types.chat.ChatCompletion` at module level, forcing these SDKs to load whenever any module imported an exception class — even for users who only need transcription.

## Changes

### Assert replacements (8 files)

| File | Count | Exception type | Purpose |
|---|---|---|---|
| `chatbot.py` | 2 | `ValueError` | Model format validation, empty message list |
| `openlrc.py` | 1 | `ValueError` | Temp folder name safety check |
| `opt.py` | 1 | `ValueError` | Segment end time required for merging |
| `preprocess.py` | 1 | `ValueError` | Audio shape mismatch after noise suppression |
| `subtitle.py` | 8 | `ValueError` | Text/segment count mismatch, LRC/SRT parsing, end time required |
| `transcribe.py` | 3 | `ValueError` | Word-level timestamps required |
| `utils.py` | 2 | `RuntimeError` | Timer not started/stopped |

### `LengthExceedException` simplification

**Before:** Constructor accepted a `ChatCompletion | Message` response object, used `isinstance` to branch on provider type, and extracted token counts with provider-specific field names. Required top-level imports of `anthropic` and `openai` types.

**After:** Constructor accepts three plain integers `(prompt_tokens, completion_tokens, total_tokens)` with default value `-1`. Callers (GPTBot, ClaudeBot) extract token counts from their response objects before raising. `exceptions.py` no longer imports any SDK types.

### `exceptions.py` is now a pure Python module

Removed `from anthropic.types import Message` and `from openai.types.chat import ChatCompletion`. This keeps the lightweight import guarantee documented in the README — importing `openlrc` or its exception classes no longer triggers SDK loading.