### PR TITLE
fix: remove duplicate word append in mid_split for continuous-scripte…

### DIFF
--- a/openlrc/transcribe.py
+++ b/openlrc/transcribe.py
@@ -217,14 +217,10 @@ class Transcriber:
                 former_words.append(word)
                 former_len += len(word.word)
 
-                # Special handling for languages without spaces between words
-                if lang in self.continuous_scripted and former_len >= splittable:
-                    if word.word.startswith(" "):
-                        break
-                    elif word.word.endswith(" "):
-                        former_words.append(word)
-                        former_len += len(word.word)
-                        break
+                # Special handling for languages without spaces between words:
+                # break at the first space boundary once we've accumulated enough text.
+                if lang in self.continuous_scripted and former_len >= splittable and " " in word.word:
+                    break
 
                 # Split at punctuation if possible
                 if former_len >= splittable and is_punct(word.word[-1]):


### PR DESCRIPTION
## Fix

`mid_split()` in `transcribe.py` appended the same word twice when splitting continuous-scripted languages (Chinese, Japanese, Thai, etc.) at a word ending with a space.

### Bug

In the splitting loop, each word is appended to `former_words` at the top of the loop body (line 217). When the word ends with a space, the `endswith(" ")` branch appended it again:

```python
for j, word in enumerate(seg_entry.words):
    former_words.append(word)          # 1st append
    former_len += len(word.word)

    if lang in self.continuous_scripted and former_len >= splittable:
        if word.word.startswith(" "):
            break
        elif word.word.endswith(" "):
            former_words.append(word)  # 2nd append — same word
            former_len += len(word.word)
            break
```

### Impact

The duplicate entry inflated `len(former_words)` by 1, causing `latter_words = seg_entry.words[len(former_words):]` to skip one word. The skipped word was silently lost from the transcription output.

Example with words `["今天", "天气", "很好 ", "我们", "出去玩"]`, splitting at index 2:

| | `former_words` | `latter_words` | Lost |
|---|---|---|---|
| Before fix | `["今天", "天气", "很好 ", "很好 "]` (len=4) | `["出去玩"]` | "我们" |
| After fix | `["今天", "天气", "很好 "]` (len=3) | `["我们", "出去玩"]` | None |

### Fix

Removed the redundant `append` and `len` update. Also simplified the two-branch `startswith`/`endswith` check into a single `" " in word.word` condition, since both branches performed the same action (`break`) and the middle-of-word space case was previously unhandled:

```python
if lang in self.continuous_scripted and former_len >= splittable and " " in word.word:
    break
```