### PR TITLE
refactor: centralize test configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENLRC_TEST_LLM_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       OPENLRC_TEST_LIVE_API: "1"
       OPENLRC_LOG_LEVEL: "DEBUG"
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+#  Copyright (C) 2026. Hao Zheng
+#  All rights reserved.
+
+"""Shared test configuration.
+
+All values can be overridden via environment variables so that developers
+can point tests at a local vLLM instance or use different models without
+editing source code.
+
+Environment variables:
+    OPENLRC_TEST_LLM_BASE_URL   LLM API base URL (default: OpenRouter)
+    OPENLRC_TEST_LLM_API_KEY    LLM API key
+    OPENLRC_TEST_MODEL_GPT      Model name for GPT tests
+    OPENLRC_TEST_MODEL_CLAUDE   Model name for Claude tests
+    OPENLRC_TEST_MODEL_GEMINI   Model name for Gemini tests
+    OPENLRC_TEST_LIVE_API       Set to "1" to enable live API tests
+    OPENLRC_TEST_STRESS         Set to "1" to enable stress tests
+"""
+
+import os
+
+from openlrc.models import ModelConfig, ModelProvider
+
+TEST_LLM_BASE_URL = os.environ.get("OPENLRC_TEST_LLM_BASE_URL", "https://openrouter.ai/api/v1")
+TEST_LLM_API_KEY = os.environ.get("OPENLRC_TEST_LLM_API_KEY")
+
+_MODEL_NAMES = {
+    "gpt": os.environ.get("OPENLRC_TEST_MODEL_GPT", "openai/gpt-5-nano"),
+    "claude": os.environ.get("OPENLRC_TEST_MODEL_CLAUDE", "anthropic/claude-haiku-4.5"),
+    "gemini": os.environ.get("OPENLRC_TEST_MODEL_GEMINI", "google/gemini-2.5-flash-lite"),
+}
+
+TEST_MODELS: dict[str, ModelConfig] = {
+    key: ModelConfig(
+        provider=ModelProvider.OPENAI,
+        name=name,
+        base_url=TEST_LLM_BASE_URL,
+        api_key=TEST_LLM_API_KEY,
+    )
+    for key, name in _MODEL_NAMES.items()
+}
+
+LIVE_API = os.environ.get("OPENLRC_TEST_LIVE_API", "").lower() in ("1", "true", "yes")
+STRESS_TEST = os.environ.get("OPENLRC_TEST_STRESS", "").lower() in ("1", "true", "yes")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -14,19 +14,8 @@ from pydantic import BaseModel
 from openlrc.agents import ChunkedTranslatorAgent, ContextReviewerAgent, TranslationContext, create_chatbot
 from openlrc.chatbot import GPTBot
 from openlrc.context import TranslateInfo
-from openlrc.models import ModelConfig, ModelProvider
 from openlrc.prompter import ChunkedTranslatePrompter
-
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
-OPENROUTER_CHEAP_MODEL = ModelConfig(
-    provider=ModelProvider.OPENAI,
-    name="google/gemini-2.5-flash-lite",
-    base_url=OPENROUTER_BASE_URL,
-    api_key=OPENROUTER_API_KEY,
-)
-LIVE_API = os.environ.get("OPENLRC_TEST_LIVE_API", "").lower() in ("1", "true", "yes")
-STRESS_TEST = os.environ.get("OPENLRC_TEST_STRESS", "").lower() in ("1", "true", "yes")
+from tests.conftest import LIVE_API, STRESS_TEST, TEST_LLM_API_KEY, TEST_MODELS
 
 
 class DummyMessage(BaseModel):
@@ -126,8 +115,8 @@ class TestTranslatorAgent(unittest.TestCase):
 class TestContextReviewerAgent(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
 
     def test_generates_valid_context(self):
         texts = [
@@ -139,7 +128,7 @@ class TestContextReviewerAgent(unittest.TestCase):
         title = "The Detectors"
         glossary = {"suspect": "嫌疑人", "uptown": "市中心"}
 
-        bot = create_chatbot(OPENROUTER_CHEAP_MODEL)
+        bot = create_chatbot(TEST_MODELS["gemini"])
         self.addCleanup(bot.close)
         agent = ContextReviewerAgent("en", "zh", chatbot=bot)
         context = agent.build_context(texts, title, glossary)
@@ -341,8 +330,8 @@ class TestChunkedGuidelineLive(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
         if not LONG_SUBTITLE_PATH.exists():
             raise unittest.SkipTest(f"Test fixture not found: {LONG_SUBTITLE_PATH}")
 
@@ -355,7 +344,7 @@ class TestChunkedGuidelineLive(unittest.TestCase):
 
     def test_baseline_single_pass(self) -> None:
         """Large-window model generates a valid guideline in one pass."""
-        bot = create_chatbot(OPENROUTER_CHEAP_MODEL)
+        bot = create_chatbot(TEST_MODELS["gemini"])
         self.addCleanup(bot.close)
         agent = ContextReviewerAgent("en", "zh", chatbot=bot)
 
@@ -379,7 +368,7 @@ class TestChunkedGuidelineLive(unittest.TestCase):
     @unittest.skipUnless(STRESS_TEST, "Requires OPENLRC_TEST_STRESS=1 (tokenizer mismatch may cause failures on CI)")
     def test_chunked_16k_window(self) -> None:
         """Simulated 16K window triggers ~3 chunks; closest to the real scenario in PR #103."""
-        model = copy(OPENROUTER_CHEAP_MODEL)
+        model = copy(TEST_MODELS["gemini"])
         model.context_window = 16384
         model.max_tokens = 4096
 
@@ -409,7 +398,7 @@ class TestChunkedGuidelineLive(unittest.TestCase):
 
     def test_chunked_8k_window(self) -> None:
         """Simulated 8K window triggers ~6 chunks; merged guideline should be non-empty."""
-        model = copy(OPENROUTER_CHEAP_MODEL)
+        model = copy(TEST_MODELS["gemini"])
         model.context_window = 8192
         model.max_tokens = 2048
 
@@ -462,7 +451,7 @@ class TestChunkedGuidelineLive(unittest.TestCase):
 
     def test_latency_and_reliability(self) -> None:
         """Run chunked generation multiple times and log latency/success statistics."""
-        model = copy(OPENROUTER_CHEAP_MODEL)
+        model = copy(TEST_MODELS["gemini"])
         model.context_window = 8192
         model.max_tokens = 2048
 
@@ -506,7 +495,7 @@ class TestChunkedGuidelineLive(unittest.TestCase):
 
     def test_stress_4k_window(self) -> None:
         """4K window forces ~15 chunks and hierarchical merging; must not crash."""
-        model = copy(OPENROUTER_CHEAP_MODEL)
+        model = copy(TEST_MODELS["gemini"])
         model.context_window = 4096
         model.max_tokens = 1024
 

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,6 +1,5 @@
 #  Copyright (C) 2025. Hao Zheng
 #  All rights reserved.
-import os
 import unittest
 from unittest.mock import patch
 
@@ -9,16 +8,7 @@ import openai
 from pydantic import BaseModel
 
 from openlrc.chatbot import ClaudeBot, GPTBot, route_chatbot
-
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
-OPENROUTER_MODELS = {
-    "gpt": "openai/gpt-5-nano",
-    "claude": "anthropic/claude-haiku-4.5",
-    "gemini": "google/gemini-2.5-flash-lite",
-}
-
-LIVE_API = os.environ.get("OPENLRC_TEST_LIVE_API", "").lower() in ("1", "true", "yes")
+from tests.conftest import LIVE_API, TEST_LLM_API_KEY, TEST_LLM_BASE_URL, TEST_MODELS
 
 
 class Usage(BaseModel):
@@ -43,14 +33,14 @@ class OpenAIResponse(BaseModel):
 class TestChatBot(unittest.TestCase):
     def setUp(self):
         self.gpt_bot = GPTBot(
-            model_name=OPENROUTER_MODELS["gpt"],
+            model_name=TEST_MODELS["gpt"].name,
             temperature=1,
             top_p=1,
             retry=8,
             max_async=16,
             fee_limit=0.05,
-            base_url_config={"openai": OPENROUTER_BASE_URL},
-            api_key=OPENROUTER_API_KEY or "test-key",
+            base_url_config={"openai": TEST_LLM_BASE_URL},
+            api_key=TEST_LLM_API_KEY or "test-key",
         )
         self.claude_bot = ClaudeBot(
             model_name="claude-3-5-sonnet-20241022",
@@ -70,8 +60,8 @@ class TestChatBot(unittest.TestCase):
             retry=8,
             max_async=16,
             fee_limit=0.05,
-            base_url_config={"openai": OPENROUTER_BASE_URL},
-            api_key=OPENROUTER_API_KEY,
+            base_url_config={"openai": TEST_LLM_BASE_URL},
+            api_key=TEST_LLM_API_KEY,
         )
 
     def test_estimate_fee(self):
@@ -113,9 +103,9 @@ class TestChatBot(unittest.TestCase):
 
     @unittest.skipUnless(LIVE_API, "Requires OPENLRC_TEST_LIVE_API=1")
     def test_gpt_message_async(self):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
-        bot = self._make_openrouter_bot(OPENROUTER_MODELS["gpt"])
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
+        bot = self._make_openrouter_bot(TEST_MODELS["gpt"].name)
         messages_list = [[{"role": "user", "content": "Echo hello:"}], [{"role": "user", "content": "Echo hello:"}]]
         results = bot.message(messages_list)
 
@@ -123,9 +113,9 @@ class TestChatBot(unittest.TestCase):
 
     @unittest.skipUnless(LIVE_API, "Requires OPENLRC_TEST_LIVE_API=1")
     def test_claude_message_async(self):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
-        bot = self._make_openrouter_bot(OPENROUTER_MODELS["claude"])
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
+        bot = self._make_openrouter_bot(TEST_MODELS["claude"].name)
         messages_list = [[{"role": "user", "content": "Echo hello:"}], [{"role": "user", "content": "Echo hello:"}]]
         results = bot.message(messages_list)
 
@@ -133,9 +123,9 @@ class TestChatBot(unittest.TestCase):
 
     @unittest.skipUnless(LIVE_API, "Requires OPENLRC_TEST_LIVE_API=1")
     def test_gpt_message_seq(self):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
-        bot = self._make_openrouter_bot(OPENROUTER_MODELS["gpt"])
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
+        bot = self._make_openrouter_bot(TEST_MODELS["gpt"].name)
         messages_list = [[{"role": "user", "content": "Echo hello:"}]]
         results = bot.message(messages_list)
 
@@ -143,9 +133,9 @@ class TestChatBot(unittest.TestCase):
 
     @unittest.skipUnless(LIVE_API, "Requires OPENLRC_TEST_LIVE_API=1")
     def test_claude_message_seq(self):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
-        bot = self._make_openrouter_bot(OPENROUTER_MODELS["claude"])
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
+        bot = self._make_openrouter_bot(TEST_MODELS["claude"].name)
         messages_list = [[{"role": "user", "content": "Echo hello:"}]]
         results = bot.message(messages_list)
         assert "hello" in bot.get_content(results[0]).lower()
@@ -364,12 +354,12 @@ class TestGeminiBot(unittest.TestCase):
     #     os.environ.pop('HTTPS_PROXY')
 
     def test_multi_turn(self):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
         bot = GPTBot(
-            model_name=OPENROUTER_MODELS["gemini"],
-            base_url_config={"openai": OPENROUTER_BASE_URL},
-            api_key=OPENROUTER_API_KEY,
+            model_name=TEST_MODELS["gemini"].name,
+            base_url_config={"openai": TEST_LLM_BASE_URL},
+            api_key=TEST_LLM_API_KEY,
         )
         result = bot.message(
             [

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,7 +1,6 @@
 #  Copyright (C) 2026. Hao Zheng
 #  All rights reserved.
 
-import os
 import unittest
 from pathlib import Path
 
@@ -9,48 +8,23 @@ import openai
 
 from openlrc.agents import create_chatbot
 from openlrc.media_utils import get_similarity
-from openlrc.models import ModelConfig, ModelProvider
 from openlrc.translate import LLMTranslator
-
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
-
-test_models = [
-    ModelConfig(
-        provider=ModelProvider.OPENAI,
-        name="openai/gpt-5-nano",
-        base_url=OPENROUTER_BASE_URL,
-        api_key=OPENROUTER_API_KEY,
-    ),
-    ModelConfig(
-        provider=ModelProvider.OPENAI,
-        name="anthropic/claude-haiku-4.5",
-        base_url=OPENROUTER_BASE_URL,
-        api_key=OPENROUTER_API_KEY,
-    ),
-    ModelConfig(
-        provider=ModelProvider.OPENAI,
-        name="google/gemini-2.5-flash-lite",
-        base_url=OPENROUTER_BASE_URL,
-        api_key=OPENROUTER_API_KEY,
-    ),
-]
-LIVE_API = os.environ.get("OPENLRC_TEST_LIVE_API", "").lower() in ("1", "true", "yes")
+from tests.conftest import LIVE_API, TEST_LLM_API_KEY, TEST_MODELS
 
 
 @unittest.skipUnless(LIVE_API, "Requires OPENLRC_TEST_LIVE_API=1 and valid API keys")
 class TestLLMTranslator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if not OPENROUTER_API_KEY:
-            raise unittest.SkipTest("OPENROUTER_API_KEY is required for LLM integration tests.")
+        if not TEST_LLM_API_KEY:
+            raise unittest.SkipTest("OPENLRC_TEST_LLM_API_KEY is required for LLM integration tests.")
 
     def tearDown(self) -> None:
         compare_path = Path("translate_intermediate.json")
         compare_path.unlink(missing_ok=True)
 
     def test_single_chunk_translation(self):
-        for chatbot_model in test_models:
+        for chatbot_model in TEST_MODELS.values():
             text = "Hello, how are you?"
             chatbot = create_chatbot(chatbot_model)
             try:
@@ -62,7 +36,7 @@ class TestLLMTranslator(unittest.TestCase):
             self.assertGreater(get_similarity(translation, "Hola, ¿cómo estás?"), 0.5)
 
     def test_multiple_chunk_translation(self):
-        for chatbot_model in test_models:
+        for chatbot_model in TEST_MODELS.values():
             texts = ["Hello, how are you?", "I am fine, thank you."]
             chatbot = create_chatbot(chatbot_model)
             try:
@@ -74,7 +48,7 @@ class TestLLMTranslator(unittest.TestCase):
             self.assertGreater(get_similarity(translations[1], "Estoy bien, gracias."), 0.5)
 
     def test_different_language_translation(self):
-        for chatbot_model in test_models:
+        for chatbot_model in TEST_MODELS.values():
             text = "Hello, how are you?"
             chatbot = create_chatbot(chatbot_model)
             try:
@@ -92,7 +66,7 @@ class TestLLMTranslator(unittest.TestCase):
                 chatbot.close()
 
     def test_empty_text_list_translation(self):
-        for chatbot_model in test_models:
+        for chatbot_model in TEST_MODELS.values():
             texts = []
             chatbot = create_chatbot(chatbot_model)
             try:
@@ -103,7 +77,7 @@ class TestLLMTranslator(unittest.TestCase):
             self.assertEqual(translations, [])
 
     def test_atomic_translate(self):
-        for chatbot_model in test_models:
+        for chatbot_model in TEST_MODELS.values():
             texts = ["Hello, how are you?", "I am fine, thank you."]
             chatbot = create_chatbot(chatbot_model)
             try:


### PR DESCRIPTION
## Centralize test configuration into conftest.py

### Problem

`OPENROUTER_BASE_URL`, `OPENROUTER_API_KEY`, `OPENROUTER_MODELS`, and `LIVE_API` were duplicated across `test_chatbot.py`, `test_agents.py`, and `test_translate.py`. Model names and URLs were hardcoded, making it impossible to point tests at a local vLLM instance without editing source code.

### Changes

**New `tests/conftest.py`** — single source of truth for all shared test constants:

| Python constant | Environment variable | Default |
|---|---|---|
| `TEST_LLM_BASE_URL` | `OPENLRC_TEST_LLM_BASE_URL` | `https://openrouter.ai/api/v1` |
| `TEST_LLM_API_KEY` | `OPENLRC_TEST_LLM_API_KEY` | `None` |
| `TEST_MODELS["gpt"]` | `OPENLRC_TEST_MODEL_GPT` | `openai/gpt-5-nano` |
| `TEST_MODELS["claude"]` | `OPENLRC_TEST_MODEL_CLAUDE` | `anthropic/claude-haiku-4.5` |
| `TEST_MODELS["gemini"]` | `OPENLRC_TEST_MODEL_GEMINI` | `google/gemini-2.5-flash-lite` |
| `LIVE_API` | `OPENLRC_TEST_LIVE_API` | `False` |
| `STRESS_TEST` | `OPENLRC_TEST_STRESS` | `False` |

`TEST_MODELS` is a `dict[str, ModelConfig]` that replaces the previous `OPENROUTER_MODELS` (dict of strings), `OPENROUTER_TEST_MODELS` (list of ModelConfig), and `OPENROUTER_CHEAP_MODEL` (single ModelConfig).

**Updated test files** — replaced all `OPENROUTER_*` definitions with imports from conftest. Cleaned up unused imports (`os`, `ModelConfig`, `ModelProvider`).

**Updated CI** — added `OPENLRC_TEST_LLM_API_KEY` env var in `ci.yml`, mapped to the existing `OPENROUTER_API_KEY` secret. The original `OPENROUTER_API_KEY` env var is retained because `GPTBot._resolve_client_settings` reads it at runtime as a fallback.

### Usage

```bash
# Default: uses OpenRouter
pytest tests/

# Override to use local vLLM
OPENLRC_TEST_LLM_BASE_URL=http://localhost:8000/v1 \
OPENLRC_TEST_LLM_API_KEY=token-xxx \
OPENLRC_TEST_MODEL_GPT=Qwen/Qwen3.5-27B-AWQ \
pytest tests/
```